### PR TITLE
update nginx server name and README

### DIFF
--- a/nginx/README.md
+++ b/nginx/README.md
@@ -31,6 +31,7 @@ Or follow the steps in that file.
 Add the following to your hosts file in `/etc/hosts`:
 
 ```
+127.0.0.1   contribute.thegulocal.com
 127.0.0.1   mem.thegulocal.com
 127.0.0.1   profile.thegulocal.com
 ```

--- a/nginx/contributions.conf
+++ b/nginx/contributions.conf
@@ -1,5 +1,5 @@
 server {
-    server_name giraffe.thegulocal.com;
+    server_name contribute.thegulocal.com;
 
     location / {
         proxy_pass http://localhost:9111/;
@@ -10,7 +10,7 @@ server {
 
 server {
     listen 443;
-    server_name giraffe.thegulocal.com;
+    server_name contribute.thegulocal.com;
 
     ssl on;
     ssl_certificate keys/mem-thegulocal-com-exp2017-03-31-bundle.crt;


### PR DESCRIPTION
Name changed from giraffe.thegulocal.com to contribute.thegulocal.com because it makes more sense to  keep the name in line with what it will be publicly. Also, updated README to instruct on what to add to their hosts file. 
