### PR TITLE
Remove slashes from routes

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -11,11 +11,11 @@ GET            /assets/*file                controllers.Assets.versioned(path="/
 GET            /                            controllers.Giraffe.contributeRedirect
 GET            /healthcheck                 controllers.Healthcheck.healthcheck
 
-GET            /uk/                         controllers.Giraffe.contributeUK
-GET            /us/                         controllers.Giraffe.contributeUSA
-GET            /au/                         controllers.Giraffe.contributeAustralia
-GET            /eu/                         controllers.Giraffe.contributeEurope
-GET            /:countryGroup/              controllers.Giraffe.contribute(countryGroup: com.gu.i18n.CountryGroup)
+GET            /uk                         controllers.Giraffe.contributeUK
+GET            /us                         controllers.Giraffe.contributeUSA
+GET            /au                         controllers.Giraffe.contributeAustralia
+GET            /eu                         controllers.Giraffe.contributeEurope
+GET            /:countryGroup              controllers.Giraffe.contribute(countryGroup: com.gu.i18n.CountryGroup)
 
 GET            /thank-you                  controllers.Giraffe.thanksUK
 GET            /us/thank-you               controllers.Giraffe.thanksUSA


### PR DESCRIPTION
The slashes were resulting in, for example, contribute.theguardian.com/uk not working, as it required contribute.theguardian.com/uk/
