### PR TITLE
Add the default Play security headers filter

### DIFF
--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -11,6 +11,7 @@ import filters.CheckCacheHeadersFilter
 import play.api.BuiltInComponents
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
+import play.filters.headers.{SecurityHeadersConfig, SecurityHeadersFilter}
 import services.PaymentServices
 import router.Routes
 
@@ -47,7 +48,12 @@ trait AppComponents extends BuiltInComponents with PlayComponents {
   lazy val assetController = wire[Assets]
 
 
-  override lazy val httpFilters: Seq[EssentialFilter] = Seq(wire[CheckCacheHeadersFilter])
+  override lazy val httpFilters: Seq[EssentialFilter] = Seq(
+    wire[CheckCacheHeadersFilter],
+    SecurityHeadersFilter(SecurityHeadersConfig(
+      contentSecurityPolicy = None
+    ))
+  )
 
   val prefix: String = "/"
   lazy val router: Router = wire[Routes]

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ val memsubCommonPlayAuth = "com.gu" %% "memsub-common-play-auth" % "1.0"
 libraryDependencies ++= Seq(
   cache,
   ws,
+  filters,
   "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test,
     scalaUri,
     scalaz,


### PR DESCRIPTION
https://www.playframework.com/documentation/2.5.x/SecurityHeaders

I've disabled CSP for the time being, we use inline scripts and enabling a sensible CSP while they're present looks tricky?

Added headers are:

```
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Permitted-Cross-Domain-Policies: master-only
```

cc @AWare 
