### PR TITLE
Remove tailing `/` (slash) from urls

### DIFF
--- a/app/controllers/Giraffe.scala
+++ b/app/controllers/Giraffe.scala
@@ -84,10 +84,10 @@ class Giraffe(paymentServices: PaymentServices) extends Controller {
   val maxAmount: Option[Int] = 2000.some
 
 
-  def contributeRedirect = /*NoCache*/Action { implicit request =>
+  def contributeRedirect = NoCacheAction { implicit request =>
     val countryGroup = request.getFastlyCountry.getOrElse(CountryGroup.RestOfTheWorld)
-    val url = MakeGiraffeRedirectURL(request, countryGroup)
-    Redirect(url, SEE_OTHER)
+
+    Redirect(routes.Giraffe.contribute(countryGroup).absoluteURL(), SEE_OTHER)
   }
 
   // Once things have settled down and we have a reasonable idea of what might
@@ -156,21 +156,3 @@ class Giraffe(paymentServices: PaymentServices) extends Controller {
     })
   }
 }
-
-object MakeGiraffeRedirectURL {
-
-  def getRedirectCountryCodeGiraffe(countryGroup: CountryGroup): CountryGroup = {
-    countryGroup match {
-      case CountryGroup.UK => CountryGroup.UK
-      case CountryGroup.US => CountryGroup.US
-      case CountryGroup.Australia => CountryGroup.Australia
-      case CountryGroup.Europe => CountryGroup.Europe
-      case _ => CountryGroup.UK
-    }
-  }
-  def apply(request: Request[AnyContent], countryGroup: CountryGroup) = {
-    val x = Uri.parse(request.uri).withScheme("https")
-    x.copy(pathParts = Seq(PathPart(getRedirectCountryCodeGiraffe(countryGroup).id)) ++ x.pathParts)
-  }
-}
-

--- a/conf/routes
+++ b/conf/routes
@@ -11,7 +11,7 @@ GET            /assets/*file                controllers.Assets.versioned(path="/
 GET            /                            controllers.Giraffe.contributeRedirect
 GET            /healthcheck                 controllers.Healthcheck.healthcheck
 
-GET            /:countryGroup/              controllers.Giraffe.contribute(countryGroup: com.gu.i18n.CountryGroup)
+GET            /:countryGroup               controllers.Giraffe.contribute(countryGroup: com.gu.i18n.CountryGroup)
 
 GET            /:countryGroup/thank-you    controllers.Giraffe.thanks(countryGroup: com.gu.i18n.CountryGroup)
 


### PR DESCRIPTION
This will give us:

https://contribute.theguardian.com/uk

...rather than:

https://contribute.theguardian.com/uk/

Note that the redirect code (that redirects from https://contribute.theguardian.com/ to a country-specific page) has been fixed, as that killed a previous attempt to remove these bad slashes: https://github.com/guardian/contributions-frontend/pull/25 .

cc @AWare @jranks123 
