### PR TITLE
add australia to navigation

### DIFF
--- a/app/views/fragments/global/controlNavigation.scala.html
+++ b/app/views/fragments/global/controlNavigation.scala.html
@@ -67,7 +67,7 @@
             </a>
             <nav id="js-country-switcher" role="navigation" class="js-dropdown-menu nav-popup is-hidden" aria-label="Country switcher">
                 <ul class="nav-popup__list">
-                @for(countryGroup <- Seq(UK, Europe, US, Canada, RestOfTheWorld)) {
+                @for(countryGroup <- Seq(UK, Europe, US, Canada, Australia, RestOfTheWorld)) {
                     <li class="nav-popup__item">
                         <a href="@routes.Giraffe.contribute(countryGroup)" class="nav-popup__link">@countryGroup.name (@countryGroup.currency.identifier)</a>
                     </li>


### PR DESCRIPTION
The country selector at the top of the page doesn't currently display Australia as an option.  If you go to the australian url you will see Australia selected but it will not be an option in the dropdown and you will not be able to get back if you change countries (unless you manually change the url)
