### PR TITLE
Fix T&C's links

### DIFF
--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -2,6 +2,7 @@
 @import views.support.ChosenVariants
 @import views.support.PageInfo
 @import views.support.Asset
+@import configuration.Links
 
 @(pageInfo:PageInfo,maxAmount: Option[Int], countryGroup: CountryGroup, chosenVariants: ChosenVariants, cmpCode: Option[String], intCmpCode: Option[String])
 
@@ -211,14 +212,14 @@
 
                             <div class="fieldset__note">
                                 <p>By proceeding, you are agreeing to our
-                                    <a href="@@Links.giraffeTerms" class="text-link" target="_blank" data-shown="gbp eur">
+                                    <a href="@Links.giraffeTerms" class="text-link" target="_blank" data-shown="gbp eur">
                                         Terms and Conditions</a>
-                                    <a href="@@Links.giraffeTermsAustralia" class="text-link" target="_blank" data-shown="aud">
+                                    <a href="@Links.giraffeTermsAustralia" class="text-link" target="_blank" data-shown="aud">
                                         Terms and Conditions</a>
-                                    <a href="@@Links.giraffeTermsUS" class="text-link" target="_blank" data-shown="usd">
+                                    <a href="@Links.giraffeTermsUS" class="text-link" target="_blank" data-shown="usd">
                                         Terms and Conditions</a>
                                     and
-                                    <a href="@@Links.guardianPrivacyPolicy" class="text-link" target="_blank">
+                                    <a href="@Links.guardianPrivacyPolicy" class="text-link" target="_blank">
                                         Privacy Policy</a>.
                                 </p>
                             </div>


### PR DESCRIPTION
The links are broken on PROD: 

https://contribute.theguardian.com/@Links.giraffeTerms

This is due to a small error in the template that was introduced in the refactor.  This PR fixes this issue.
