### PR TITLE
Fix redirect on / to include campaign codes

### DIFF
--- a/app/controllers/Giraffe.scala
+++ b/app/controllers/Giraffe.scala
@@ -89,8 +89,9 @@ class Giraffe(paymentServices: PaymentServices) extends Controller {
 
   def contributeRedirect = NoCacheAction { implicit request =>
     val countryGroup = request.getFastlyCountry.getOrElse(CountryGroup.RestOfTheWorld)
+    val CampaignCodesToForward = Set("INTCMP", "CMP", "mcopy")
 
-    Redirect(routes.Giraffe.contribute(countryGroup).url, SEE_OTHER)
+    Redirect(routes.Giraffe.contribute(countryGroup).url, request.queryString.filterKeys(CampaignCodesToForward), SEE_OTHER)
   }
 
   // Once things have settled down and we have a reasonable idea of what might


### PR DESCRIPTION
The redirect from:

(https://contribute.theguardian.com/?INTCMP=article-1-everyone)

 Is missing campaign codes:

(https://contribute.theguardian.com/uk)

This PR ensures that the campaign codes are retained on the redirect.
