### PR TITLE
Update webpack config to allow use of webpack-dev-server

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -190,20 +190,6 @@ module.exports = function (grunt) {
                     atBegin: true
                 }
             },
-            compile_js: {
-                files: ['<%= dirs.assets.javascripts %>/**/*.js'],
-                tasks: ['compile:js'],
-                options: {
-                    atBegin: true
-                }
-            },
-            compile_es6: {
-                files: ['<%= dirs.assets.javascripts %>/**/*.es6'],
-                tasks: ['compile:js'],
-                options: {
-                    atBegin: true
-                }
-            },
             compile_images: {
                 files: ['<%= dirs.assets.images %>/**/*'],
                 tasks: ['compile:images'],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,7 +51,7 @@ module.exports = function (grunt) {
          ***********************************************************************/
 
         webpack: {
-            options: require('./webpack.conf.js')(isDev),
+            options: isDev ? require('./webpack.config.js') : require('./webpack.config.prod.js'),
             frontend: {
                 output: {
                     path: 'public/',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "compile": "echo 'compiling assets' && grunt compile",
     "compileCss": "grunt compile:css --dev",
     "compileJs": "grunt compile:js --dev",
-    "watch": "grunt watch --dev",
+    "watch": "concurrently --kill-others 'grunt watch --dev' 'webpack-dev-server --port 7777'",
     "test": "grunt validate && grunt karma",
     "postinstall": "npm run bowerSetup"
   },
@@ -22,6 +22,7 @@
     "bean": "~1.0.15",
     "bonzo": "~2.0.0",
     "bower": "^1.7.9",
+    "concurrently": "^2.2.0",
     "curl-amd": "~0.8.12",
     "domready": "~1.0.8",
     "grunt": "^1.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,79 @@
+var path = require('path');
+
+module.exports = {
+    resolve: {
+        root: ["assets/javascripts", "node_modules"],
+        extensions: ["", ".js", ".es6"],
+        alias: {
+            '$$': 'src/utils/$',
+            //'lodash': 'lodash-amd/modern',
+            'bean': 'bean/bean',
+            'bonzo': 'bonzo/bonzo',
+            'qwery': 'qwery/qwery',
+            'reqwest': 'reqwest/reqwest',
+            'respimage': 'respimage/respimage',
+            'lazySizes': 'lazysizes/lazysizes',
+            'gumshoe': 'gumshoe/dist/js/gumshoe',
+            'smoothScroll': 'smooth-scroll/dist/js/smooth-scroll',
+            'ajax': 'src/utils/ajax'
+        }
+    },
+
+    module: {
+        loaders: [
+            {
+                test: /\.es6$/,
+                exclude: /node_modules/,
+                loader: 'babel',
+                query: {
+                    presets: ['es2015'],
+                    cacheDirectory: ''
+                }
+            },
+
+            {
+                test: /\.jsx$/,
+                exclude: /node_modules/,
+                loader: 'babel',
+                query: {
+                    presets: ['react', 'es2015'],
+                    cacheDirectory: ''
+                }
+            }
+        ]
+    },
+
+    resolveLoader: {
+        root: path.join(__dirname, "node_modules")
+    },
+
+    progress: true,
+    failOnError: true,
+    keepalive: false,
+    inline: true,
+
+    stats: {
+        modules: true,
+        reasons: true,
+        colors: true
+    },
+
+    debug: false,
+    devtool: 'source-map',
+    entry: 'src/main',
+
+    output: {
+        path: path.resolve(__dirname, "public"),
+        publicPath: "/javascripts/",
+        filename: "main.js"
+    },
+
+    devServer: {
+        proxy: {
+            '/*': {
+                target: 'http://localhost:9000',
+                secure: false
+            }
+        }
+    }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,14 +58,17 @@ module.exports = {
         colors: true
     },
 
+    context: 'assets/javascripts',
+
     debug: false,
     devtool: 'source-map',
     entry: 'src/main',
 
     output: {
         path: path.resolve(__dirname, "public"),
-        publicPath: "/javascripts/",
-        filename: "main.js"
+        chunkFilename:  'webpack/[chunkhash].js',
+        filename: "javascripts/[name].js",
+        publicPath: '/assets/'
     },
 
     devServer: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,8 +1,9 @@
 var Uglify = require("webpack/lib/optimize/UglifyJsPlugin");
+var path = require('path');
 
-module.exports = function(debug) { return {
+module.exports = {
     resolve: {
-        root: ["assets/javascripts", "assets/../node_modules/"],
+        root: ["assets/javascripts", "node_modules"],
         extensions: ["", ".js", ".es6"],
         alias: {
             '$$': 'src/utils/$',
@@ -29,13 +30,25 @@ module.exports = function(debug) { return {
                     presets: ['es2015'],
                     cacheDirectory: ''
                 }
+            },
+
+            {
+                test: /\.jsx$/,
+                exclude: /node_modules/,
+                loader: 'babel',
+                query: {
+                    presets: ['react', 'es2015'],
+                    cacheDirectory: ''
+                }
             }
         ]
     },
 
-    plugins: !debug ? [
-        new Uglify({compress: {warnings: false}})
-    ] : [],
+    resolveLoader: {
+        root: path.join(__dirname, "node_modules")
+    },
+
+    plugins: new Uglify({ compress: { warnings: false }}),
 
     progress: true,
     failOnError: true,
@@ -51,6 +64,5 @@ module.exports = function(debug) { return {
     },
 
     context: 'assets/javascripts',
-    debug: false,
-    devtool: 'source-map'
-}};
+    debug: false
+};

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -64,5 +64,6 @@ module.exports = {
     },
 
     context: 'assets/javascripts',
-    debug: false
+    debug: false,
+    devtool: 'source-map'
 };

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -48,7 +48,7 @@ module.exports = {
         root: path.join(__dirname, "node_modules")
     },
 
-    plugins: new Uglify({ compress: { warnings: false }}),
+    plugins: [new Uglify({ compress: { warnings: false }})],
 
     progress: true,
     failOnError: true,


### PR DESCRIPTION
A couple of tweaks to the configs so the dev server works. This proxies all requests to the backend but allows for live reloading of files in the bundle. The command is:

```
webpack-dev-server --port 7777
```

You can then access `http://localhost:7777/webpack-dev-server/uk-react/` for hot reloading goodness! 

@AWare 
