### PR TITLE
Use SAMEORIGIN for X-FRAME-OPTIONS

### DIFF
--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -51,7 +51,8 @@ trait AppComponents extends BuiltInComponents with PlayComponents {
   override lazy val httpFilters: Seq[EssentialFilter] = Seq(
     wire[CheckCacheHeadersFilter],
     SecurityHeadersFilter(SecurityHeadersConfig(
-      contentSecurityPolicy = None
+      contentSecurityPolicy = None,
+      frameOptions = Some("SAMEORIGIN")
     ))
   )
 


### PR DESCRIPTION
This will allow us to use webpack-dev-server locally and still prevent anyone framing the page.
`ALLOW-FROM` is [badly supported](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) so I think this is a better way. @rtyley 
