### PR TITLE
Use newer, faster Riff-Raff deploy format

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.2")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.6")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.1")


### PR DESCRIPTION
> "Even more exciting news, you shouldn't need to change anything, but if you're using sbt-riffraff-artifact and upgrade to 0.9.1, builds and deploys should get a little faster and previewing a deploy should get much faster." - @philwills 

See also https://github.com/guardian/riff-raff/pull/311 & https://github.com/guardian/sbt-riffraff-artifact/pull/25
