### PR TITLE
ignore more of public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ assets/images/inline-svgs/*.svg
 /assets/images/svg-sprite.svg
 /public/dist/
 /public/webpack/
+/public/images/
 /public/*.js
 /public/*.js.map
 /assets/javascripts/lib/bower-components/


### PR DESCRIPTION
I removed the public rule from gitignore now that 🤖.txt lives there
Maybe it would be more sustainable to put robots.txt in assets and have grunt copy it and just ignore the whole public dir.
