### PR TITLE
Sentry release

### DIFF
--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -34,6 +34,7 @@ object SentryLogging {
         val sentryAppender = new SentryAppender(RavenFactory.ravenInstance(dsn)) {
           addFilter(filter)
           setTags(tagsString)
+          setRelease(app.BuildInfo.gitCommitId)
           setExtraTags(AllMDCTags.mkString(","))
           setContext(LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext])
         }

--- a/assets/javascripts/src/modules/raven.js
+++ b/assets/javascripts/src/modules/raven.js
@@ -16,6 +16,7 @@ define(['src/utils/user','raven-js'], function (user, Raven) {
         Raven.config(dsn, {
             whitelistUrls: [ /contribute\.theguardian\.com/, /contribute\.thegulocal\.com/, /localhost/ ],
             tags: tags,
+            release: tags.build_number,
             ignoreErrors: [ /duplicate define: jquery/ ],
             ignoreUrls: [ /platform\.twitter\.com/ ],
             shouldSendCallback: function(data) {


### PR DESCRIPTION
Sentry wants the build number in the release field. 
We're already sending this as a tag, which would now be superfluous. 

This enables release tracking in sentry. 
@mario-galic: you might want this for s-f and m-f
