### PR TITLE
Changed cookie length from 2 weeks to 1 week

### DIFF
--- a/app/views/support/ABTest.scala
+++ b/app/views/support/ABTest.scala
@@ -141,7 +141,7 @@ object Test {
   }
 
   def createCookie(variant: TestTrait#Variant): Cookie = {
-    Cookie(variant.testSlug+"_GIRAFFE_TEST", variant.variantSlug, maxAge = Some(1209600))
+    Cookie(variant.testSlug+"_GIRAFFE_TEST", variant.variantSlug, maxAge = Some(604800))
   }
 
   def getContributePageVariants[A](countryGroup: CountryGroup,request: Request[A]) = {


### PR DESCRIPTION
#304 in Trello.

The cookie expiration was 2 weeks. This meant that once someone was opted into an AB test, they couldn't be put into a new variant for a whole 2 weeks. This PR shortens that time to 1 week
