### PR TITLE
Update return url for sign out

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -10,7 +10,7 @@ object Config {
   val logger = Logger(this.getClass)
 
   val config = ConfigFactory.load()
-  val membershipUrl = config.getString("membership.url")
+  val contributeUrl = config.getString("contribute.url")
   val facebookAppId = config.getString("facebook.app.id")
   val idWebAppUrl = config.getString("identity.webapp.url")
 
@@ -19,7 +19,7 @@ object Config {
   val stageDev: Boolean = stage == "DEV"
   val googleAnalyticsTrackingId = config.getString("google.analytics.tracking.id")
   def idWebAppSigninUrl(uri: String): String =
-    (idWebAppUrl / "signin") ? ("returnUrl" -> s"$membershipUrl$uri") & idSkipConfirmation
+    (idWebAppUrl / "signin") ? ("returnUrl" -> s"$contributeUrl$uri") & idSkipConfirmation
   private val idSkipConfirmation: (String, String) = "skipConfirmation" -> "true"
 
 

--- a/app/configuration/Links.scala
+++ b/app/configuration/Links.scala
@@ -35,7 +35,7 @@ object ProfileLinks {
   val changePassword =  Config.idWebAppUrl / "password/change"
 
   def signOut(path: String) = {
-    Config.idWebAppUrl / "signout" ? ("returnUrl" -> (Config.membershipUrl + path))
+    Config.idWebAppUrl / "signout" ? ("returnUrl" -> (Config.contributeUrl + path))
   }
 
 }

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -39,7 +39,7 @@
             {
                 "@@context": "http://schema.org",
                 "@@type": "Organization",
-                "name": "Guardian Members",
+                "name": "Contribute",
                 "url": "@(Config.contributeUrl)",
                 "logo": "@(Config.contributeUrl)@Asset.at("images/favicons/152x152.png")",
                 "sameAs" : [

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -27,7 +27,7 @@
         @for(pageImage <- pageInfo.image) {
             <meta property="og:image" content="@pageImage"/>
         }
-        <meta property="og:url" content="@(Config.membershipUrl + pageInfo.url)"/>
+        <meta property="og:url" content="@(Config.contributeUrl + pageInfo.url)"/>
 
         <meta property="og:type" content="website"/>
         <meta property="fb:app_id" content="@Config.facebookAppId"/>
@@ -40,8 +40,8 @@
                 "@@context": "http://schema.org",
                 "@@type": "Organization",
                 "name": "Guardian Members",
-                "url": "@(Config.membershipUrl)",
-                "logo": "@(Config.membershipUrl)@Asset.at("images/favicons/152x152.png")",
+                "url": "@(Config.contributeUrl)",
+                "logo": "@(Config.contributeUrl)@Asset.at("images/favicons/152x152.png")",
                 "sameAs" : [
                     "@(Social.youtube)",
                     "@(Social.googleplus)",

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -24,7 +24,7 @@ identity {
     webapp.url="https://profile-origin.thegulocal.com"
 }
 
-membership.url="https://mem.thegulocal.com"
+contribute.url="https://contribute.thegulocal.com"
 members-data-api.url="http://members-data-api.thegulocal.com"
 
 // https://console.developers.google.com/project/guardian-membership/apiui/credential?authuser=1

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -27,7 +27,7 @@ identity {
     webapp.url="https://profile.theguardian.com"
 }
 
-membership.url="https://membership.theguardian.com"
+contribute.url="https://contribute.theguardian.com"
 members-data-api.url="https://members-data-api.theguardian.com"
 
 // https://console.developers.google.com/project/guardian-membership/apiui/credential?authuser=1


### PR DESCRIPTION
Previously, sign out was sending users to membership frontend rather than back to contribute. This fixes that issue. 
