### PR TITLE
Add variants for interactive test

### DIFF
--- a/app/controllers/Giraffe.scala
+++ b/app/controllers/Giraffe.scala
@@ -99,7 +99,7 @@ class Giraffe(paymentServices: PaymentServices) extends Controller {
   def redirectToUk = NoCacheAction { implicit request => redirectWithCampaignCodes(routes.Giraffe.contribute(UK).url) }
 
   private def redirectWithCampaignCodes(destinationUrl: String)(implicit request: Request[Any]) = {
-    val CampaignCodesToForward = Set("INTCMP", "CMP", "mcopy")
+    val CampaignCodesToForward = Set("INTCMP", "CMP", "mcopy", "highlight")
     Redirect(destinationUrl, request.queryString.filterKeys(CampaignCodesToForward), SEE_OTHER)
   }
 

--- a/app/views/support/ABTest.scala
+++ b/app/views/support/ABTest.scala
@@ -64,10 +64,10 @@ object AmountHighlightTest extends TestTrait {
   )
 
   def variants = NonEmptyList(
-    Variant("Amount - 50 highlight", "25", 0, contributeAmountButtons(List(25, 50, 100, 250), Some(25)), notAustralia),
+    Variant("Amount - 25 highlight", "25", 0, contributeAmountButtons(List(25, 50, 100, 250), Some(25)), notAustralia),
     Variant("Amount - 50 highlight", "50", 1, contributeAmountButtons(List(25, 50, 100, 250), Some(50)), notAustralia),
-    Variant("Amount - 50 highlight", "100", 0, contributeAmountButtons(List(25, 50, 100, 250), Some(100)), notAustralia),
-    Variant("Amount - 50 highlight", "250", 0, contributeAmountButtons(List(25, 50, 100, 250), Some(250)), notAustralia),
+    Variant("Amount - 100 highlight", "100", 0, contributeAmountButtons(List(25, 50, 100, 250), Some(100)), notAustralia),
+    Variant("Amount - 250 highlight", "250", 0, contributeAmountButtons(List(25, 50, 100, 250), Some(250)), notAustralia),
     Variant("Amount - 100 highlight Australia", "100-Australia", 1, contributeAmountButtons(List(50, 100, 250, 500), Some(100)), Set(Australia))
   )
 }

--- a/app/views/support/ABTest.scala
+++ b/app/views/support/ABTest.scala
@@ -64,18 +64,12 @@ object AmountHighlightTest extends TestTrait {
   )
 
   def variants = NonEmptyList(
-    Variant("Amount - 5 highlight", "5", 0, contributeAmountButtons(List(5, 25, 50, 100), Some(5))),
-    Variant("Amount - 25 highlight", "25", 0, contributeAmountButtons(List(5, 25, 50, 100), Some(25))),
-    Variant("Amount - no highlight", "None", 0, contributeAmountButtons(List(5, 25, 50, 100), None)),
-    Variant("Amount - 35 highlight", "35", 0, contributeAmountButtons(List(10, 35, 65, 100), Some(35))),
-    Variant("Amount - 35 highlight descending", "35-descending", 0, contributeAmountButtons(List(100, 65, 35, 10), Some(35))),
-    Variant("Amount - 100 highlight", "100", 0, contributeAmountButtons(List(25, 50, 100, 250), Some(100))),
+    Variant("Amount - 50 highlight", "25", 0, contributeAmountButtons(List(25, 50, 100, 250), Some(25)), notAustralia),
     Variant("Amount - 50 highlight", "50", 1, contributeAmountButtons(List(25, 50, 100, 250), Some(50)), notAustralia),
-    Variant("Amount - 15", "15", 0, contributeAmountButtons(List(15, 35, 65, 100), Some(35))),
-    Variant("Amount - 40 highlight", "40", 0, contributeAmountButtons(List(20, 40, 75, 100), Some(40))),
+    Variant("Amount - 50 highlight", "100", 0, contributeAmountButtons(List(25, 50, 100, 250), Some(100)), notAustralia),
+    Variant("Amount - 50 highlight", "250", 0, contributeAmountButtons(List(25, 50, 100, 250), Some(250)), notAustralia),
     Variant("Amount - 100 highlight Australia", "100-Australia", 1, contributeAmountButtons(List(50, 100, 250, 500), Some(100)), Set(Australia))
   )
-
 }
 
 object MessageCopyTest extends TestTrait {


### PR DESCRIPTION
For the interactive embed test, we need the user to be able to select either 25, 50, 100 or 250 in the interactive in the article and have that amount preselected when they get through to the page. This PR facilitates that. 
