### PR TITLE
Second page copy logic for contributions interactive embed

### DIFF
--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -69,9 +69,9 @@
                     </div>
 
                     <div class="form__column js-hidden-tablet js-details">
-                        <h3 class="form__column-heading form__column-heading--first headline-text--bolder details-heading doNotSkip">
+                        <h3 class="form__column-heading form__column-heading--first headline-text--bolder details-heading js-default-heading">
                             Your details</h3>
-                        <h3 class="form__column-heading form__column-heading--first headline-text--bolder details-heading doSkip" >
+                        <h3 class="form__column-heading form__column-heading--first headline-text--bolder details-heading js-amount-heading" >
                             Continue with your
                                 <br>
                                 contribution of <span class="js-currency-pay">@countryGroup.currency.prefix@countryGroup.currency.glyph</span><span class="js-amount js-pay"></span>

--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -69,8 +69,14 @@
                     </div>
 
                     <div class="form__column js-hidden-tablet js-details">
-                        <h3 class="form__column-heading form__column-heading--first headline-text--bolder">
+                        <h3 class="form__column-heading form__column-heading--first headline-text--bolder details-heading doNotSkip">
                             Your details</h3>
+                        <h3 class="form__column-heading form__column-heading--first headline-text--bolder details-heading doSkip" >
+                            Continue with your
+                                <br>
+                                contribution of <span class="js-currency-pay">@countryGroup.currency.prefix@countryGroup.currency.glyph</span><span class="js-amount js-pay"></span>
+                        </h3>
+
                         <ul class="u-unstyled">
                             <li class="form-field">
                                 <label for="name" class="label">Full name</label>
@@ -103,6 +109,7 @@
                         <a class="action action--contribute js-advance action--advance" data-switches="js-payment">
                             Next
                         </a>
+
                     </div>
 
 

--- a/assets/javascripts/src/modules/giraffe.es6
+++ b/assets/javascripts/src/modules/giraffe.es6
@@ -42,8 +42,8 @@ export function init() {
     }
 
     if (shouldSkipAmount()) {
-        $('.doSkip').addClass('js-skip');
-        $('.doNotSkip').addClass('js-skip');
+        $('.js-amount-heading').addClass('js-skip');
+        $('.js-default-heading').addClass('js-skip');
         transition(DETAILS_CLASS);
     }
 

--- a/assets/javascripts/src/modules/giraffe.es6
+++ b/assets/javascripts/src/modules/giraffe.es6
@@ -41,7 +41,13 @@ export function init() {
         return;
     }
 
-    if (shouldSkipAmount()) transition(DETAILS_CLASS);
+    if (shouldSkipAmount()) {
+        $('.doSkip').addClass('js-skip');
+        $('.doNotSkip').addClass('js-skip');
+        transition(DETAILS_CLASS);
+    }
+
+
     ophanId();
     carousel();
 
@@ -77,7 +83,6 @@ export function init() {
     if(!hiddenAmount){
         $('.js-currency-pay').addClass(HIDDEN_CLASS);
     }
-
 
     getStuffFromIdentity();
 }

--- a/assets/stylesheets/giraffe.scss
+++ b/assets/stylesheets/giraffe.scss
@@ -253,26 +253,26 @@ $desktop-col-padding-right: 16px;
     }
 }
 
-.doSkip{
+.js-amount-heading{
     display:none;
 }
 
 
 @include mq($from: tablet) {
-    .doSkip.js-skip {
+    .js-amount-heading.js-skip {
         display:block;
     }
-    .doNotSkip.js-skip {
+    .js-default-heading.js-skip {
         display:none;
     }
 }
 
 
 @include mq($until: tablet) {
-    .doSkip.js-skip {
+    .js-amount-heading.js-skip {
         display:none;
     }
-    .doNotSkip.js-skip {
+    .js-default-heading.js-skip {
         display:block;
     }
 }

--- a/assets/stylesheets/giraffe.scss
+++ b/assets/stylesheets/giraffe.scss
@@ -186,6 +186,7 @@ $desktop-col-padding-right: 16px;
         padding-left: $desktop-col-padding-left;
         padding-right: $desktop-col-padding-right;
     }
+
 }
 
 /** Thanks */
@@ -251,6 +252,32 @@ $desktop-col-padding-right: 16px;
         font-size: 18px;
     }
 }
+
+.doSkip{
+    display:none;
+}
+
+
+@include mq($from: tablet) {
+    .doSkip.js-skip {
+        display:block;
+    }
+    .doNotSkip.js-skip {
+        display:none;
+    }
+}
+
+
+@include mq($until: tablet) {
+    .doSkip.js-skip {
+        display:none;
+    }
+    .doNotSkip.js-skip {
+        display:block;
+    }
+}
+
+
 
 @include mq($from: desktop) {
 


### PR DESCRIPTION
When the user comes in from the contributions interactive embed (CIB), they have already chosen their amount so they need to be taken to the second page of the form and see different copy acknowledging that they have already chosen their contribution amount, unless they are on mobile, where this is not applicable

This PR implements this copy logic. 

![screenshot at aug 23 13-31-47](https://cloud.githubusercontent.com/assets/2844554/17891892/5d592ede-6936-11e6-8ab0-e106473c6d37.png)

^ What the second page looks like if you come from the CIB on tablet or larger

![screenshot at aug 23 13-32-41](https://cloud.githubusercontent.com/assets/2844554/17891900/62448dc6-6936-11e6-9da4-9d10aaa9786b.png)

^ What the second page looks like if you come from a normal link

![screenshot at aug 23 13-32-28](https://cloud.githubusercontent.com/assets/2844554/17891896/6013d1a6-6936-11e6-8cde-bfe56be12d03.png)

^ What the form looks like on mobile, regardless of where you came from 
