### PR TITLE
always display the "secure" label and the padlock

### DIFF
--- a/assets/javascripts/src/components/Title.jsx
+++ b/assets/javascripts/src/components/Title.jsx
@@ -15,14 +15,12 @@ export default class Title extends React.Component {
                 {titlesByPageId[this.props.page]}
             </h3>
 
-            {this.props.page === PAGES.PAYMENT &&
-                <div className="security-note">
-                    <svg className="icon-inline icon-inline--small icon-inline--top">
-                        <use xmlnsXlink="http://www.w3.org/1999/xlink" xlinkHref="#icon-secure"></use>
-                    </svg>
-                    This site is secure
-                </div>
-            }
+            <div className="security-note">
+                <svg className="icon-inline icon-inline--small icon-inline--top">
+                    <use xmlnsXlink="http://www.w3.org/1999/xlink" xlinkHref="#icon-secure"></use>
+                </svg>
+                Secure
+            </div>
 
         </div>;
     }


### PR DESCRIPTION
Changed the copy to "Secure" and always display it.

cc @desbo 
