### PR TITLE
Remove compile_js from grunt:watch task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -190,13 +190,6 @@ module.exports = function (grunt) {
                 options: {
                     atBegin: true
                 }
-            },
-            compile_js: {
-                files: ['<%= dirs.assets.javascripts %>/**/*.js'],
-                tasks: ['compile:js'],
-                options: {
-                    atBegin: true
-                }
             }
         },
 


### PR DESCRIPTION
We don't need this because `webpack-dev-server` takes care of compiling JS in dev (via `npm run watch`). 
