### PR TITLE
Test payments not working

### DIFF
--- a/assets/javascripts/src/actions.es6
+++ b/assets/javascripts/src/actions.es6
@@ -29,6 +29,7 @@ export function submitPayment(dispatch) {
     stripe.createToken(state.card)
         .then(token => paymentFormData(state, token))
         .then(data => fetch(urls.pay, {
+            credentials: 'same-origin',
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(data)
@@ -53,6 +54,7 @@ export function paypalRedirect(dispatch) {
             amount: state.card.amount //TODO should the amount be somewhere else rather than in the card section?
         };
     fetch('/paypal/auth', {
+        credentials: 'same-origin',
         method: 'POST',
         headers: {
             'Accept': 'application/json',


### PR DESCRIPTION
On the react version of the frontend we execute payments as ajax requests using fetch.
Fetch will not send cookies in a post unless a specific option is provided. 
This probably makes our posts unauthenticated so we get the live version of all services.
https://github.com/github/fetch#sending-cookies
