### PR TITLE
terms & conditions and privacy policy

### DIFF
--- a/app/views/fragments/giraffe/legalNotice.scala.html
+++ b/app/views/fragments/giraffe/legalNotice.scala.html
@@ -1,6 +1,6 @@
 @(termsAndConditionsLink: String)()
-<p>By proceeding, you are agreeing to our <a href="@termsAndConditionsLink"> Terms &amp; Conditions</a>
-    and <a href="http://www.theguardian.com/help/privacy-policy"> Privacy Policy</a>.</p>
+<p>By proceeding, you are agreeing to our <a href="@termsAndConditionsLink" className="text-link" target="_blank"> Terms &amp; Conditions</a>
+    and <a href="http://www.theguardian.com/help/privacy-policy" className="text-link" target="_blank"> Privacy Policy</a>.</p>
 <p>If you have any questions about contributing to the Guardian, please
     <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">
         contact us here</a>.

--- a/app/views/fragments/giraffe/legalNotice.scala.html
+++ b/app/views/fragments/giraffe/legalNotice.scala.html
@@ -1,4 +1,4 @@
 @(termsAndConditionsLink: String)()
-    <p>By proceeding, you are agreeing to our <a href="@termsAndConditionsLink"> Terms & Conditions</a>
+    <p>By proceeding, you are agreeing to our <a href="@termsAndConditionsLink"> Terms &amp; Conditions</a>
         and <a href="http://www.theguardian.com/help/privacy-policy"> Privacy Policy</a>.</p>
 

--- a/app/views/fragments/giraffe/legalNotice.scala.html
+++ b/app/views/fragments/giraffe/legalNotice.scala.html
@@ -1,0 +1,4 @@
+@(termsAndConditionsLink: String)()
+    <p>By proceeding, you are agreeing to our <a href="@termsAndConditionsLink"> Terms & Conditions</a>
+        and <a href="http://www.theguardian.com/help/privacy-policy"> Privacy Policy</a>.</p>
+

--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -52,38 +52,49 @@
         <div class="support-wrapper page-slice page-slice__feedback l-constrained currency-@countryGroup.currency.toString.toLowerCase">
             <div class="feedback">
 
-                <p data-shown="gbp eur">If you have any questions about contributing to the Guardian, please
-                    <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">
-                        contact us here</a>.
-                </p>
-                <p data-shown="gbp eur">
+                <div data-shown="gbp eur">
+                    @fragments.giraffe.legalNotice("https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions")
+                    <p>If you have any questions about contributing to the Guardian, please
+                        <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">
+                            contact us here</a>.
+                    </p>
+
+                </div>
+                <div data-shown="gbp eur">
                     The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
-                </p>
+                </div>
 
 
-                <p data-shown="aud">If you have any questions about contributing to the Guardian, please
+                <div data-shown="aud">
+                    @fragments.giraffe.legalNotice("https://www.theguardian.com/info/2016/apr/08/australia-contribution-terms-and-conditions")
+                    If you have any questions about contributing to the Guardian, please
                     <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">
                         contact us here</a>.
-                </p>
-                <p data-shown="aud">
+                </div>
+                <div data-shown="aud">
                     The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
-                </p>
-                <p data-shown="usd">If you have any questions about contributing to the Guardian, please
-                    <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">
-                        contact us here</a>.
-                </p>
-                <p data-shown="usd">
+                </div>
+                <div data-shown="usd">
+                    @fragments.giraffe.legalNotice("https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions")
+
+                    <p>
+                        If you have any questions about contributing to the Guardian, please
+                        <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">
+                            contact us here</a>.
+                    </p>
+                </div>
+                <div data-shown="usd">
                     The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
-                </p>
-                <p data-shown="gbp aud eur">
+                </div>
+                <div data-shown="gbp aud eur">
                     Please note that your support of the Guardian’s journalism does not constitute a charitable donation, as such your contribution is not eligible for Gift Aid in the UK nor a tax-deduction elsewhere.
-                </p>
-                <p data-shown="usd">
+                </div>
+                <div data-shown="usd">
                     Please note that the Guardian is not a charity, will not use your support for charitable
                     programs, and your support of the Guardian’s journalism does not constitute a
                     charitable donation. As such your contribution is not eligible to be treated as a
                     charitable deduction for federal or state taxes in the United States or elsewhere.
-                </p>
+                </div>
             </div>
         </div>
     </section>

--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -52,29 +52,29 @@
         <div class="support-wrapper page-slice page-slice__feedback l-constrained currency-@countryGroup.currency.toString.toLowerCase">
             <div class="feedback">
 
-                <div data-shown="gbp eur">
+                <section data-shown="gbp eur">
                     @fragments.giraffe.legalNotice("https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions")
                     <p>If you have any questions about contributing to the Guardian, please
                         <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">
                             contact us here</a>.
                     </p>
 
-                </div>
-                <div data-shown="gbp eur">
+                </section>
+                <section data-shown="gbp eur">
                     The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
-                </div>
+                </section>
 
 
-                <div data-shown="aud">
+                <section data-shown="aud">
                     @fragments.giraffe.legalNotice("https://www.theguardian.com/info/2016/apr/08/australia-contribution-terms-and-conditions")
                     If you have any questions about contributing to the Guardian, please
                     <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">
                         contact us here</a>.
-                </div>
-                <div data-shown="aud">
+                </section>
+                <section data-shown="aud">
                     The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
-                </div>
-                <div data-shown="usd">
+                </section>
+                <section data-shown="usd">
                     @fragments.giraffe.legalNotice("https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions")
 
                     <p>
@@ -82,19 +82,19 @@
                         <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">
                             contact us here</a>.
                     </p>
-                </div>
-                <div data-shown="usd">
+                </section>
+                <section data-shown="usd">
                     The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
-                </div>
-                <div data-shown="gbp aud eur">
+                </section>
+                <section data-shown="gbp aud eur">
                     Please note that your support of the Guardian’s journalism does not constitute a charitable donation, as such your contribution is not eligible for Gift Aid in the UK nor a tax-deduction elsewhere.
-                </div>
-                <div data-shown="usd">
+                </section>
+                <section data-shown="usd">
                     Please note that the Guardian is not a charity, will not use your support for charitable
                     programs, and your support of the Guardian’s journalism does not constitute a
                     charitable donation. As such your contribution is not eligible to be treated as a
                     charitable deduction for federal or state taxes in the United States or elsewhere.
-                </div>
+                </section>
             </div>
         </div>
     </section>

--- a/assets/javascripts/src/components/LegalNotice.jsx
+++ b/assets/javascripts/src/components/LegalNotice.jsx
@@ -15,7 +15,7 @@ export default class LegalNotice extends React.Component {
 
         return (
             <div className="fieldset__note">
-                <p>By proceeding, you are agreeing to our <a href={termsURL} className="text-link" target="_blank">Terms & Conditions</a> and <a href="http://www.theguardian.com/help/privacy-policy" className="text-link" target="_blank">Privacy Policy</a></p>
+                <p>By proceeding, you are agreeing to our <a href={termsURL} className="text-link" target="_blank">Terms &amp; Conditions</a> and <a href="http://www.theguardian.com/help/privacy-policy" className="text-link" target="_blank">Privacy Policy</a></p>
             </div>
         );
     }

--- a/assets/javascripts/src/components/LegalNotice.jsx
+++ b/assets/javascripts/src/components/LegalNotice.jsx
@@ -4,7 +4,7 @@ const urls = {
     'uk': 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
     'eur': 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
     'us': 'https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions',
-    'aus': 'https://www.theguardian.com/info/2016/apr/08/australia-contribution-terms-and-conditions'
+    'au': 'https://www.theguardian.com/info/2016/apr/08/australia-contribution-terms-and-conditions'
 }
 
 const defaultURL = 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions';
@@ -15,8 +15,7 @@ export default class LegalNotice extends React.Component {
 
         return (
             <div className="fieldset__note">
-                <p>By proceeding, you are agreeing to our <a href={termsURL} className="text-link" target="_blank">Terms and Conditions</a></p>
-                <p><a href="http://www.theguardian.com/help/privacy-policy" className="text-link" target="_blank">Privacy Policy</a></p>
+                <p>By proceeding, you are agreeing to our <a href={termsURL} className="text-link" target="_blank">Terms & Conditions</a> and <a href="http://www.theguardian.com/help/privacy-policy" className="text-link" target="_blank">Privacy Policy</a></p>
             </div>
         );
     }

--- a/assets/stylesheets/giraffe-react.scss
+++ b/assets/stylesheets/giraffe-react.scss
@@ -354,7 +354,7 @@ $currencies: gbp usd aud eur nzd cad;
         display: flex;
         flex-direction: row;
         justify-content: space-around;
-        div {
+        section {
             display: block;
             padding-left: $tablet-col-padding-left;
             padding-right: $tablet-col-padding-right;

--- a/assets/stylesheets/giraffe-react.scss
+++ b/assets/stylesheets/giraffe-react.scss
@@ -354,7 +354,7 @@ $currencies: gbp usd aud eur nzd cad;
         display: flex;
         flex-direction: row;
         justify-content: space-around;
-        p {
+        div {
             display: block;
             padding-left: $tablet-col-padding-left;
             padding-right: $tablet-col-padding-right;


### PR DESCRIPTION
- Changed format
- fixed australia link
- added links to t&c and privacy policy in the disclamer section so PayPal users can see it

![legalbefore](https://cloud.githubusercontent.com/assets/15324270/18321748/4434db22-7527-11e6-87e1-b80350b02f3e.png)
![legal](https://cloud.githubusercontent.com/assets/15324270/18321756/4e35988c-7527-11e6-9f2c-f24ef44c7686.png)
