### PR TITLE
Android contributions fix

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -12,6 +12,7 @@ GET            /assets/*file                    controllers.Assets.versioned(pat
 
 # Giraffe
 GET            /                                controllers.Giraffe.contributeRedirect
+GET            /home                            controllers.Giraffe.contributeRedirect
 GET            /healthcheck                     controllers.Healthcheck.healthcheck
 POST           /paypal/auth                     controllers.PaypalController.authorize
 


### PR DESCRIPTION
There is a bug in the android app where it redirects all Guardian domains ending in / to the home screen. i.e. https://contribute.theguardian.com/ redirects to the home page.  

Chrome always adds a / to urls that don't contain one therefore simply changing the URL in Composer doesn't work.  

This change allow's us to link to this url thus forcing GeoIP and fixing the link in the Android App.  

Once the Android app is patched we will remove this work-around.
