### PR TITLE
Non Urgent paypal fixes 

### DIFF
--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -76,7 +76,9 @@ class PaypalController(
         )
         authResponse match {
           case Right(url) => Ok(Json.toJson(AuthResponse(url)))
-          case Left(error) => handleError(authRequest.countryGroup, s"Error getting PayPal auth url: $error")
+          case Left(error) =>
+            Logger.error(s"Error getting PayPal auth url: $error")
+            InternalServerError("Error getting PayPal auth url")
         }
       case JsError(error) =>
 

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -7,11 +7,13 @@ import play.api.libs.ws.WSClient
 import play.api.mvc.{BodyParsers, Controller, Result}
 import services.PaymentServices
 import play.api.Logger
-import play.api.libs.json._
 import utils.ContributionIdGenerator
 import views.support.Test
 import utils.MaxAmount
 import scala.util.Right
+import play.api.libs.json._
+import play.api.libs.json.Reads._
+import play.api.libs.functional.syntax._
 
 
 class PaypalController(
@@ -46,9 +48,17 @@ class PaypalController(
     intCmp: Option[String],
     ophanId: Option[String]
   )
+
   object AuthRequest {
-    implicit val jf = Json.reads[AuthRequest]
+    implicit val authRequestReads: Reads[AuthRequest] = (
+      (__ \ "countryGroup").read[CountryGroup] and
+        (__ \ "amount").read(min[BigDecimal](1)) and
+        (__ \ "cmp").readNullable[String] and
+        (__ \ "intCmp").readNullable[String] and
+        (__ \ "ophanId").readNullable[String]
+      ) (AuthRequest.apply _)
   }
+
   case class AuthResponse(approvalUrl:String)
 
   implicit val AuthResponseWrites = Json.writes[AuthResponse]

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -81,8 +81,7 @@ class PaypalController(
             InternalServerError("Error getting PayPal auth url")
         }
       case JsError(error) =>
-
-        Logger.warn(s"Invalid request=$error")
+        Logger.error(s"Invalid request=$error")
         BadRequest(s"Invalid request=$error")
     }
   }

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -15,6 +15,7 @@ import org.joda.time.DateTime
 import play.api.Logger
 import views.support.ChosenVariants
 
+import scala.math.BigDecimal.RoundingMode
 import scala.util.{Failure, Success, Try}
 
 case class PaypalCredentials(clientId: String, clientSecret: String)
@@ -66,8 +67,9 @@ class PaypalService(config: PaypalApiConfig, contributionData: ContributionData)
     }
     val cancelUrl = config.baseReturnUrl
     val currencyCode = countryGroup.currency.toString
-    val paypalAmount = new Amount().setCurrency(currencyCode).setTotal(amount.toString)
-    val item = new Item().setDescription(description).setCurrency(currencyCode).setPrice(amount.toString).setQuantity("1")
+    val stringAmount = amount.setScale(2, RoundingMode.HALF_UP).toString
+    val paypalAmount = new Amount().setCurrency(currencyCode).setTotal(stringAmount)
+    val item = new Item().setDescription(description).setCurrency(currencyCode).setPrice(stringAmount).setQuantity("1")
     val itemList = new ItemList().setItems(List(item).asJava)
     val transaction = new Transaction
     transaction.setAmount(paypalAmount)

--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -13,9 +13,9 @@
         @for(message <- errorMessage) {
             <div id="errorDialog" class="overlay">
                 <div>
-                    <h1 class="GuardianEgyptianWeb-RegularItalic errorHeader">We're sorry</h1>
-                    <p class="GuardianTextSansWeb-Black errorMessage">@message</p>
-                    <button class="action" id="errorDialogButton">OK</button>
+                    <h1 class="errorHeader">We're sorry</h1>
+                    <p class="errorMessage">@message</p>
+                    <button class="action action--button contribute-navigation__next" id="errorDialogButton">OK</button>
 
                 </div>
             </div>

--- a/assets/stylesheets/giraffe-react.scss
+++ b/assets/stylesheets/giraffe-react.scss
@@ -11,7 +11,7 @@
     position: fixed;
     display: flex;
     z-index: 1000;
-    background: rgba(0, 0, 0, 0.6);
+    background: rgba(0, 0, 0, 0.7);
     align-items: center;
     left: 0px;
     top: 0px;
@@ -38,17 +38,17 @@
     font-size: 20px;
     font-weight: 900;
     line-height: 24px;
+    font-family: "Guardian Egyptian Web";
 }
 
 .errorMessage {
     margin-top: 10px;
     font-size: 14px;
     line-height: 18px;
-
+    font-family: "Guardian Text Sans Web";
 }
 
 .overlay button {
-    background-color: #005689;
     height: 36px;
     width: 60px;
     text-align: center;


### PR DESCRIPTION
We can merge this after the code freeze.
Changes:
- Return an error status when posting to paypal/auth instead of redirecting to the error page 
- Some server side validations that are already performed client side: 
  - Round the PayPal amount to the required string representation with 2 decimal places before making the PayPal api call. 
  - Validate amount should be at least 1
- Change the label from "continue" to "pay now" in the last step on PayPal's side . 
- Small changes to PayPal error message style 
