### PR TITLE
Update and fix webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "time-grunt": "^1.4.0",
     "vinyl-fs": "2.4.3",
     "webpack": "^1.13.1",
-    "webpack-dev-server": "^1.14.1",
+    "webpack-dev-server": "^1.15.1",
     "whatwg-fetch": "^1.0.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "time-grunt": "^1.4.0",
     "vinyl-fs": "2.4.3",
     "webpack": "^1.13.1",
-    "webpack-dev-server": "^1.15.1",
+    "webpack-dev-server": "1.15.1",
     "whatwg-fetch": "^1.0.0"
   },
   "jest": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,7 +78,7 @@ module.exports = {
 
     devServer: {
         proxy: {
-            '/*': {
+            '**': {
                 target: 'http://localhost:9111',
                 secure: false
             }


### PR DESCRIPTION
The syntax for the proxy config [has changed](https://github.com/webpack/webpack-dev-server/issues/562) in the current version of webpack-dev-server.
Although we specify the version in package.json, this actually needs to be installed globally (ignoring package.json version), so it's better to make it compatible with the latest one. 
