### PR TITLE
Ophan fixes

### DIFF
--- a/assets/javascripts/src/modules/abTests.es6
+++ b/assets/javascripts/src/modules/abTests.es6
@@ -6,23 +6,20 @@ import { SET_AMOUNT } from 'src/actions';
 
 export function init() {
     const state = store.getState();
+    const data = {};
 
-    if ("abTests" in window) {
-        var data = {};
-
-        for (var test of abTests) {
-            data[test.testSlug] = {
-                'variantName': test.variantSlug,
-                'complete': 'false'
-            }
+    for (var test of state.data.abTests) {
+        data[test.testSlug] = {
+            'variantName': test.variantSlug,
+            'complete': 'false'
         }
-
-        ophan.loaded.then(function (ophan) {
-            ophan.record({
-                abTestRegister: data
-            })
-        });
     }
+
+    ophan.loaded.then(function (ophan) {
+        ophan.record({
+            abTestRegister: data
+        })
+    });
 
     // only set the amount from the A/B test if it isn't already set
     // this prevents the A/B test overriding the preset amount (query param) functionality)

--- a/assets/javascripts/src/modules/abTests.es6
+++ b/assets/javascripts/src/modules/abTests.es6
@@ -13,7 +13,7 @@ export function init() {
         for (var test of abTests) {
             data[test.testSlug] = {
                 'variantName': test.variantSlug,
-                'complete': 'true'
+                'complete': 'false'
             }
         }
 

--- a/assets/javascripts/src/modules/analytics/ophan.js
+++ b/assets/javascripts/src/modules/analytics/ophan.js
@@ -1,7 +1,7 @@
 define(['src/modules/raven'],function(raven) {
     'use strict';
 
-    var ophanUrl = '//j.ophan.co.uk/membership.js';
+    var ophanUrl = '//j.ophan.co.uk/contribution.js';
     var ophan = curl(ophanUrl);
 
     function init() {


### PR DESCRIPTION
A couple of fixes to get Ophan working: 
1. use new contributions URL
2. fix submission A/B test data 

Once this is merged we'll have impressions counts for contribute.theguardian.com, which we can use along with @rtyley's contributions data to calculate conversion rates. 
