### PR TITLE
Add session stickyness to reduce problems during deployments

### DIFF
--- a/cloud-formation/contributions-app.yml
+++ b/cloud-formation/contributions-app.yml
@@ -219,6 +219,8 @@
             Protocol: "HTTPS"
             SSLCertificateId:
               Ref: "ELBSSLCertificate"
+            PolicyNames:
+              - "CookieBasedPolicy"
         SecurityGroups:
           -
             Ref: "LoadBalancerSecurityGroup"
@@ -233,6 +235,10 @@
         ConnectionDrainingPolicy:
           Enabled: "true"
           Timeout: "60"
+        LBCookieStickinessPolicy:
+          -
+            CookieExpirationPeriod: "1800"
+            PolicyName: "CookieBasedPolicy"
     LoadBalancerSecurityGroup:
       Type: "AWS::EC2::SecurityGroup"
       Properties:


### PR DESCRIPTION
When we deploy we currently have a high risk of serving a borken page to our clients.

This is because during deplpyment two competing versions of the assets may be served by different servers.
For instance, a new version of the HTML could be served by the new version of the app, while older servers may serve 404 when trying to served the corresponding hashed assets.

This will limit the problem but won't solve it. It ensures a client sticks to the same AWS instance.

It's been tested on CODE
