### PR TITLE
Add resolver for identity-cookie

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,7 @@ dependencyOverrides += "com.typesafe.play" %% "play-json" % "2.4.6"
 
 
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
+resolvers += "old-github-maven-repo" at "http://guardian.github.io/maven/repo-releases/"
 
 addCommandAlias("devrun", "run 9111")
 


### PR DESCRIPTION
In the medium term if we need this dependency we should publish it properly, but in the mean time this stops things breaking for those without it in their ivy cache.
