### PR TITLE
Paypal marketing opt in

### DIFF
--- a/app/controllers/Giraffe.scala
+++ b/app/controllers/Giraffe.scala
@@ -99,6 +99,18 @@ class Giraffe(paymentServices: PaymentServices) extends Controller {
     Redirect(destinationUrl, request.queryString.filterKeys(QueryParamsToForward), SEE_OTHER)
   }
 
+  def postPayment(countryGroup: CountryGroup) = NoCacheAction { implicit request =>
+    //TODO PAGEINFO DUPLICATION
+    val pageInfo = PageInfo(
+      title = "Support the Guardian | Contribute today",
+      url = request.path,
+      image = Some("https://media.guim.co.uk/5719a2b724efd8944e0222d57c839a7d2b6e39b3/0_0_1440_864/1000.jpg"),
+      stripePublicKey = None,
+      description = Some("By making a contribution, you'll be supporting independent journalism that speaks truth to power"),
+      customSignInUrl = Some((Config.idWebAppUrl / "signin") ? ("skipConfirmation" -> "true"))
+    )
+    Ok(views.html.giraffe.postPayment(pageInfo, countryGroup))
+  }
   def contribute(countryGroup: CountryGroup, error: Option[PaymentError] = None) = NoCacheAction { implicit request =>
     val errorMessage = error.map(_.message)
     val stripe = paymentServices.stripeServiceFor(request)

--- a/app/controllers/Giraffe.scala
+++ b/app/controllers/Giraffe.scala
@@ -22,7 +22,7 @@ import utils.RequestCountry._
 import views.support._
 import scala.concurrent.Future
 
-class Giraffe(paymentServices: PaymentServices) extends Controller {
+class Giraffe(paymentServices: PaymentServices) extends Controller with Redirect {
   implicit val currencyFormatter = new Formatter[Currency] {
     type Result = Either[Seq[FormError], Currency]
     override def bind(key: String, data: Map[String, String]): Result =
@@ -94,13 +94,9 @@ class Giraffe(paymentServices: PaymentServices) extends Controller {
 
   def redirectToUk = NoCacheAction { implicit request => redirectWithQueryParams(routes.Giraffe.contribute(UK).url) }
 
-  private def redirectWithQueryParams(destinationUrl: String)(implicit request: Request[Any]) = {
-    val QueryParamsToForward = Set("INTCMP", "CMP", "mcopy", "skipAmount", "highlight")
-    Redirect(destinationUrl, request.queryString.filterKeys(QueryParamsToForward), SEE_OTHER)
-  }
+  private def redirectWithQueryParams(destinationUrl: String)(implicit request: Request[Any]) = redirectWithCampaignCodes(destinationUrl, Set("mcopy", "skipAmount", "highlight"))
 
   def postPayment(countryGroup: CountryGroup) = NoCacheAction { implicit request =>
-    //TODO PAGEINFO DUPLICATION
     val pageInfo = PageInfo(
       title = "Support the Guardian | Contribute today",
       url = request.path,

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -50,7 +50,7 @@ class PaypalController(
         getEmail(executedPayment) match {
           case Some(email) => redirectWithCampaignCodes(postPayUrl).withSession(request.session + ("email" -> email))
           case None =>
-            Logger.error("No email returned from Paypal payment execution, skipping to thank you page")
+            Logger.error(s"No email returned from Paypal payment execution paymentId=$paymentId")
             redirectWithCampaignCodes(thanksUrl)
         }
       case Left(error) => handleError(countryGroup, s"Error executing PayPal payment: $error")

--- a/app/controllers/Redirect.scala
+++ b/app/controllers/Redirect.scala
@@ -1,0 +1,10 @@
+package controllers
+
+import play.api.mvc.{Controller, Request}
+
+trait Redirect {self: Controller =>
+  def redirectWithCampaignCodes(destinationUrl: String, additionalParams: Set[String] = Set.empty)(implicit request: Request[Any]) = {
+    val QueryParamsToForward = Set("INTCMP", "CMP") ++ additionalParams
+    Redirect(destinationUrl, request.queryString.filterKeys(QueryParamsToForward), SEE_OTHER)
+  }
+}

--- a/app/controllers/Redirect.scala
+++ b/app/controllers/Redirect.scala
@@ -2,9 +2,10 @@ package controllers
 
 import play.api.mvc.{Controller, Request}
 
-trait Redirect {self: Controller =>
+trait Redirect {
+  self: Controller =>
   def redirectWithCampaignCodes(destinationUrl: String, additionalParams: Set[String] = Set.empty)(implicit request: Request[Any]) = {
-    val QueryParamsToForward = Set("INTCMP", "CMP") ++ additionalParams
-    Redirect(destinationUrl, request.queryString.filterKeys(QueryParamsToForward), SEE_OTHER)
+    val queryParamsToForward = Set("INTCMP", "CMP") ++ additionalParams
+    Redirect(destinationUrl, request.queryString.filterKeys(queryParamsToForward), SEE_OTHER)
   }
 }

--- a/app/data/ContributionData.scala
+++ b/app/data/ContributionData.scala
@@ -79,7 +79,7 @@ class ContributionData(db: Database) {
     }
   }
 
-  def insertContributor(contributor: Contributor): Unit = {
+  def saveContributor(contributor: Contributor): Unit = {
     db.withConnection(autocommit = true) { implicit conn =>
       val request = SQL"""
         INSERT INTO live_contributors(

--- a/app/models/Contributor.scala
+++ b/app/models/Contributor.scala
@@ -3,8 +3,8 @@ package models
 case class Contributor(
   email: String,
   name: Option[String],
-  firstName: String,
-  lastName: String,
+  firstName: Option[String],
+  lastName: Option[String],
   idUser: Option[String],
   postCode: Option[String],
   marketingOptIn: Option[Boolean]

--- a/app/models/SavedContribution.scala
+++ b/app/models/SavedContribution.scala
@@ -1,3 +1,0 @@
-package models
-
-case class SavedContribution(contributionMetaData: ContributionMetaData, contributor: Contributor)

--- a/app/models/SavedContribution.scala
+++ b/app/models/SavedContribution.scala
@@ -1,0 +1,3 @@
+package models
+
+case class SavedContribution(contributionMetaData: ContributionMetaData, contributor: Contributor)

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -6,12 +6,12 @@ import com.gu.i18n.CountryGroup
 import com.netaporter.uri.Uri
 import com.paypal.api.payments._
 import com.paypal.base.Constants
-import com.paypal.base.rest.{APIContext, PayPalRESTException}
+import com.paypal.base.rest.{APIContext}
 
 import scala.collection.JavaConverters._
 import com.typesafe.config.Config
 import data.ContributionData
-import models.{ContributionMetaData, Contributor, PaymentHook, SavedContribution}
+import models.{ContributionMetaData, Contributor, PaymentHook}
 import org.joda.time.DateTime
 import play.api.Logger
 import views.support.ChosenVariants
@@ -122,7 +122,7 @@ class PaypalService(config: PaypalApiConfig, contributionData: ContributionData)
     intCmp: Option[String],
     ophanId: Option[String],
     idUser: Option[String]
-  ): Either[String,SavedContribution ] = {
+  ): Either[String,String ] = {
     val result = for {
       payment <- Try(Payment.get(apiContext, paymentId))
       transaction <- Try(payment.getTransactions.asScala.head)
@@ -166,11 +166,11 @@ class PaypalService(config: PaypalApiConfig, contributionData: ContributionData)
 
       contributionData.insertPaymentMetaData(metadata)
       contributionData.saveContributor(contributor)
-      SavedContribution(metadata,contributor)
+
     }
 
     result match {
-      case Success(data) => Right(data)
+      case Success(_) => Right(paymentId)
       case Failure(exception) =>
         Logger.error("Unable to store contribution metadata", exception)
         Left("Unable to store contribution metadata")

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -151,10 +151,9 @@ class PaypalService(config: PaypalApiConfig, contributionData: ContributionData)
 
       val firstName = Option(payerInfo.getFirstName)
       val lastName = Option(payerInfo.getLastName)
-      //TODO maybe do this in a nicer way
-      val fullName = Seq(firstName, lastName).flatten.mkString (" ") match {
-        case "" => None
-        case name => Some(name)
+      val fullName = Seq(firstName, lastName).flatten match {
+        case Nil => None
+        case names => Some(names.mkString(" "))
       }
 
       val contributor = Contributor(

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -11,7 +11,7 @@ import com.paypal.base.rest.{APIContext, PayPalRESTException}
 import scala.collection.JavaConverters._
 import com.typesafe.config.Config
 import data.ContributionData
-import models.{ContributionMetaData, Contributor, PaymentHook}
+import models.{ContributionMetaData, Contributor, PaymentHook, SavedContribution}
 import org.joda.time.DateTime
 import play.api.Logger
 import views.support.ChosenVariants
@@ -114,8 +114,6 @@ class PaypalService(config: PaypalApiConfig, contributionData: ContributionData)
         Left(exception.getMessage)
     }
   }
-
-  case class SavedContribution(contributionMetaData: ContributionMetaData, contributor: Contributor)
 
   def storeMetaData(
     paymentId: String,

--- a/app/views/fragments/giraffe/contributionsMain.scala.html
+++ b/app/views/fragments/giraffe/contributionsMain.scala.html
@@ -1,0 +1,73 @@
+@import com.gu.i18n.CountryGroup
+@import views.support.ChosenVariants
+@import views.support.PageInfo
+@import views.support.Asset
+@import views.support.CountryGroupImplicits._
+
+@import play.api.libs.json.Json
+@(pageInfo: PageInfo = views.support.PageInfo(),
+countryGroup: CountryGroup,
+maxAmount: Option[Int] = None,
+mainScript: Option[String] = None,
+errorMessage:Option[String])(content: Html)
+@main(pageInfo, Some(countryGroup), maxAmount, mainScript) {
+    <main class="giraffe__wrapper currency-@countryGroup.currency.toString.toLowerCase">
+
+        @for(message <- errorMessage) {
+            <div id="errorDialog" class="overlay">
+                <div>
+                    <h1 class="errorHeader">We're sorry</h1>
+                    <p class="errorMessage">@message</p>
+                    <button class="action action--button contribute-navigation__next" id="errorDialogButton">OK</button>
+
+                </div>
+            </div>
+        }
+
+        <div class="giraffe__inner page-slice l-constrained flex-horizontal-from-tablet">
+            <section class="giraffe__heading">
+                <h1 class="giraffe__heading--main">
+                    <span class="giraffe__heading--main--jaunty">Producing </span>
+                    <span class="giraffe__heading--main--jaunty">well-reported </span>
+                    <span class="giraffe__heading--main--jaunty">journalism </span>
+                    <span class="giraffe__heading--main--jaunty">is difficult and expensive. </span>
+                </h1>
+                <h2 class="giraffe__heading--sub">
+                    <span class="giraffe__heading--sub--jaunty">Supporting us isn’t. </span>
+                    <span class="giraffe__heading--sub--jaunty">Please give to </span>
+                    <span class="giraffe__heading--sub--jaunty">the Guardian.</span> </h2>
+            </section>
+            @content
+        </div>
+    </main>
+    <section class="disclaimer">
+        <div class="support-wrapper page-slice page-slice__feedback l-constrained currency-@countryGroup.currency.toString.toLowerCase">
+            <div class="feedback">
+                <section>
+                    <p>If you have any questions about contributing to the Guardian, please
+                        <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">
+                            contact us here</a>.
+
+                </section>
+
+                <section>
+                    <p>
+                        The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
+                    </p>
+
+                </section>
+                <section>
+                    <p data-shown="gbp aud eur">
+                        Please note that your support of the Guardian’s journalism does not constitute a charitable donation, as such your contribution is not eligible for Gift Aid in the UK nor a tax-deduction elsewhere.
+                    </p>
+                    <p data-shown="usd">
+                        Please note that the Guardian is not a charity, will not use your support for charitable
+                        programs, and your support of the Guardian’s journalism does not constitute a
+                        charitable donation. As such your contribution is not eligible to be treated as a
+                        charitable deduction for federal or state taxes in the United States or elsewhere.
+                    </p>
+                </section>
+            </div>
+        </div>
+    </section>
+}

--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -1,82 +1,21 @@
 @import com.gu.i18n.CountryGroup
 @import views.support.ChosenVariants
 @import views.support.PageInfo
-@import views.support.Asset
+@import fragments.giraffe.contributionsMain
 @import views.support.CountryGroupImplicits._
 
 @import play.api.libs.json.Json
-@(pageInfo: PageInfo, maxAmount: Int, countryGroup: CountryGroup, chosenVariants: ChosenVariants, cmpCode: Option[String], intCmpCode: Option[String], creditCardExpiryYears: List[Int], errorMessage:Option[String])
+@(pageInfo: PageInfo, maxAmount: Int, countryGroup: CountryGroup, chosenVariants: ChosenVariants, cmpCode: Option[String], intCmpCode: Option[String], creditCardExpiryYears: List[Int], errorMessage: Option[String])
 
-@main(pageInfo, Some(countryGroup), Some(maxAmount), Some("contributePage.js")) {
-    <main class="giraffe__wrapper currency-@countryGroup.currency.toString.toLowerCase">
+@contributionsMain(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage) {
 
-        @for(message <- errorMessage) {
-            <div id="errorDialog" class="overlay">
-                <div>
-                    <h1 class="errorHeader">We're sorry</h1>
-                    <p class="errorMessage">@message</p>
-                    <button class="action action--button contribute-navigation__next" id="errorDialogButton">OK</button>
-
-                </div>
-            </div>
-        }
-
-        <div class="giraffe__inner page-slice l-constrained flex-horizontal-from-tablet">
-            <section class="giraffe__heading">
-                <h1 class="giraffe__heading--main">
-                    <span class="giraffe__heading--main--jaunty">Producing </span>
-                    <span class="giraffe__heading--main--jaunty">well-reported </span>
-                    <span class="giraffe__heading--main--jaunty">journalism </span>
-                    <span class="giraffe__heading--main--jaunty">is difficult and expensive. </span>
-                </h1>
-                <h2 class="giraffe__heading--sub">
-                    <span class="giraffe__heading--sub--jaunty">Supporting us isn’t. </span>
-                    <span class="giraffe__heading--sub--jaunty">Please give to </span>
-                    <span class="giraffe__heading--sub--jaunty">the Guardian.</span> </h2>
-            </section>
-
-            <!-- react injects its components here -->
-            <section    id="contribute" class="contribute-container"
-                        data-ab-tests="@Json.stringify(chosenVariants.asJson)"
-                        data-country-group="@Json.stringify(Json.toJson(countryGroup))"
-                        data-max-amount="@maxAmount"
-                        @cmpCode.map(code => Html(s"""data-cmp-code="${code}""""))
-                        @intCmpCode.map(code => Html(s"""data-int-cmp-code="${code}""""))>
-            </section>
-        </div>
-    </main>
-
-
-
-
-    <section class="disclaimer">
-        <div class="support-wrapper page-slice page-slice__feedback l-constrained currency-@countryGroup.currency.toString.toLowerCase">
-            <div class="feedback">
-                <section>
-                    <p>If you have any questions about contributing to the Guardian, please
-                        <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">
-                            contact us here</a>.
-
-                </section>
-
-                <section>
-                    <p>
-                        The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
-                    </p>
-
-                </section>
-                <section>
-                    <p data-shown="gbp aud eur">
-                        Please note that your support of the Guardian’s journalism does not constitute a charitable donation, as such your contribution is not eligible for Gift Aid in the UK nor a tax-deduction elsewhere.
-                    </p>
-                    <p data-shown="usd">
-                        Please note that the Guardian is not a charity, will not use your support for charitable
-                        programs, and your support of the Guardian’s journalism does not constitute a
-                        charitable donation. As such your contribution is not eligible to be treated as a
-                        charitable deduction for federal or state taxes in the United States or elsewhere.
-                    </p>
-                </section>
-            </div>
-        </div>
+    <!-- react injects its components here -->
+    <section id="contribute" class="contribute-container"
+    data-ab-tests="@Json.stringify(chosenVariants.asJson)"
+    data-country-group="@Json.stringify(Json.toJson(countryGroup))"
+    data-max-amount="@maxAmount"
+        @cmpCode.map(code => Html(s"""data-cmp-code="${code}""""))
+        @intCmpCode.map(code => Html(s"""data-int-cmp-code="${code}""""))>
     </section>
+
 }

--- a/app/views/giraffe/postPayment.scala.html
+++ b/app/views/giraffe/postPayment.scala.html
@@ -15,8 +15,10 @@
             <p class ="contribute-form__title contactInformationTitle">Your contact information</p>
             <p>Receive in your inbox emails from The Guardian, Including more information about your contribution and our work on this initiative.</p>
             <form action="update-metadata" method="POST" >
-                <input type="checkbox" name="marketingOptIn" checked="true" value="true">
-                Keep me informed with updates and offers from The Guardian
+                <div class="giraffe-checkbox">
+                    <input type="checkbox" name="marketingOptIn" checked="true" value="true"/>
+                    <label htmlFor="marketingOptIn">Keep me informed with updates and offers from The Guardian</label>
+                </div>
                 <button class="action action--button action--button--forward action action--button contribute-navigation__next action--next postPaymentButton">
                     <span>Next</span>
                     <svg class="action--button__arrow" xmlns="http://www.w3.org/2000/svg" width="20" height="17.89" viewBox="0 0 20 17.89">

--- a/app/views/giraffe/postPayment.scala.html
+++ b/app/views/giraffe/postPayment.scala.html
@@ -11,7 +11,6 @@
             <p class ="contribute-form__title">Your payment was processed successfully</p>
         </div>
 
-
         <div class="contribute-section class postPaymentText">
             <p class ="contribute-form__title contactInformationTitle">Your contact information</p>
             <p>Receive in your inbox emails from The Guardian, Including more information about your contribution and our work on this initiative.</p>

--- a/app/views/giraffe/postPayment.scala.html
+++ b/app/views/giraffe/postPayment.scala.html
@@ -1,0 +1,30 @@
+@import com.gu.i18n.CountryGroup
+@import views.support.PageInfo
+@import play.api.libs.json.Json
+@import fragments.giraffe.contributionsMain
+@(pageInfo: PageInfo, countryGroup: CountryGroup)
+
+@contributionsMain(pageInfo, countryGroup, None, None, None) {
+
+    <div class="contribute-container">
+        <div class="contribute-section">
+            <p class ="contribute-form__title">Your payment was processed successfully</p>
+            </div>
+        <div class="contribute-section">
+            <p class ="contribute-form__title">Your contact information</p>
+            <p>Receive on your inbox emails from The Guardian, Including more information about your contribution and our work on this initiative.</p>
+            <form action="update-metadata" method="POST" >
+                <input type="checkbox" name="marketingOptIn" checked="true" value="true">
+                Keep me informed with updates and offers from The Guardian
+                <button class="action action--button action--button--forward action action--button contribute-navigation__next action--next postPaymentButton">
+                    <span>Next</span>
+                    <svg class="action--button__arrow" xmlns="http://www.w3.org/2000/svg" width="20" height="17.89" viewBox="0 0 20 17.89">
+                        <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84zm20-.81L49.08 0l.86.81-6.54 7.31H60v1.65H43.4l6.54 7.31-.86.81L40 9.39v-.85z"/>
+                    </svg>
+                </button>
+
+            </form>
+        </div>
+
+    </div>
+}

--- a/app/views/giraffe/postPayment.scala.html
+++ b/app/views/giraffe/postPayment.scala.html
@@ -11,9 +11,9 @@
             <p class ="contribute-form__title">Your payment was processed successfully</p>
         </div>
 
-        <div class="contribute-section class postPaymentText">
+        <div class="contribute-section">
             <p class ="contribute-form__title contactInformationTitle">Your contact information</p>
-            <p>Receive in your inbox emails from The Guardian, Including more information about your contribution and our work on this initiative.</p>
+            <p class="postPaymentText">Receive in your inbox emails from The Guardian, Including more information about your contribution and our work on this initiative.</p>
             <form action="update-metadata" method="POST" >
                 <div class="giraffe-checkbox">
                     <input type="checkbox" name="marketingOptIn" checked="true" value="true"/>

--- a/app/views/giraffe/postPayment.scala.html
+++ b/app/views/giraffe/postPayment.scala.html
@@ -6,20 +6,20 @@
 @contributionsMain(pageInfo, countryGroup, None, None, None) {
 
     <div class="contribute-container">
-        <div class="contribute-section">
-            <div class ="postPaymentTick"></div>
-            <p class ="contribute-form__title">Your payment was processed successfully</p>
+        <div class="contribute-section postPaymentConfirmation">
+            <div class ="circleBackground postPaymentTick"></div>
+            <p class =" contribute-form__title">Your payment was processed successfully</p>
         </div>
 
-        <div class="contribute-section">
-            <p class ="contribute-form__title contactInformationTitle">Your contact information</p>
-            <p class="postPaymentText">Receive in your inbox emails from the Guardian, Including more information about your contribution and our work on this initiative.</p>
+        <div class="contribute-section postPaymentContact">
+            <div class ="circleBackground postPaymentEnvelope"></div>
+            <p class ="contribute-form__title">We would like to stay in touch</p>
             <form action="update-metadata" method="POST" >
                 <div class="giraffe-checkbox">
                     <input type="checkbox" name="marketingOptIn" checked="true" value="true"/>
                     <label htmlFor="marketingOptIn">Keep me informed with updates and offers from the Guardian</label>
                 </div>
-                <button class="action action--button action--button--forward action action--button contribute-navigation__next action--next postPaymentButton">
+                <button class="action action--button action--button--forward action action--button contribute-navigation__next action--next">
                     <span>Next</span>
                     <svg class="action--button__arrow" xmlns="http://www.w3.org/2000/svg" width="20" height="17.89" viewBox="0 0 20 17.89">
                         <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84zm20-.81L49.08 0l.86.81-6.54 7.31H60v1.65H43.4l6.54 7.31-.86.81L40 9.39v-.85z"/>

--- a/app/views/giraffe/postPayment.scala.html
+++ b/app/views/giraffe/postPayment.scala.html
@@ -13,11 +13,11 @@
 
         <div class="contribute-section">
             <p class ="contribute-form__title contactInformationTitle">Your contact information</p>
-            <p class="postPaymentText">Receive in your inbox emails from The Guardian, Including more information about your contribution and our work on this initiative.</p>
+            <p class="postPaymentText">Receive in your inbox emails from the Guardian, Including more information about your contribution and our work on this initiative.</p>
             <form action="update-metadata" method="POST" >
                 <div class="giraffe-checkbox">
                     <input type="checkbox" name="marketingOptIn" checked="true" value="true"/>
-                    <label htmlFor="marketingOptIn">Keep me informed with updates and offers from The Guardian</label>
+                    <label htmlFor="marketingOptIn">Keep me informed with updates and offers from the Guardian</label>
                 </div>
                 <button class="action action--button action--button--forward action action--button contribute-navigation__next action--next postPaymentButton">
                     <span>Next</span>

--- a/app/views/giraffe/postPayment.scala.html
+++ b/app/views/giraffe/postPayment.scala.html
@@ -1,6 +1,5 @@
 @import com.gu.i18n.CountryGroup
 @import views.support.PageInfo
-@import play.api.libs.json.Json
 @import fragments.giraffe.contributionsMain
 @(pageInfo: PageInfo, countryGroup: CountryGroup)
 
@@ -8,11 +7,14 @@
 
     <div class="contribute-container">
         <div class="contribute-section">
+            <div class ="postPaymentTick"></div>
             <p class ="contribute-form__title">Your payment was processed successfully</p>
-            </div>
-        <div class="contribute-section">
-            <p class ="contribute-form__title">Your contact information</p>
-            <p>Receive on your inbox emails from The Guardian, Including more information about your contribution and our work on this initiative.</p>
+        </div>
+
+
+        <div class="contribute-section class postPaymentText">
+            <p class ="contribute-form__title contactInformationTitle">Your contact information</p>
+            <p>Receive in your inbox emails from The Guardian, Including more information about your contribution and our work on this initiative.</p>
             <form action="update-metadata" method="POST" >
                 <input type="checkbox" name="marketingOptIn" checked="true" value="true">
                 Keep me informed with updates and offers from The Guardian
@@ -25,6 +27,5 @@
 
             </form>
         </div>
-
     </div>
 }

--- a/assets/stylesheets/giraffe-react.scss
+++ b/assets/stylesheets/giraffe-react.scss
@@ -8,33 +8,47 @@ $control-spacing: 5px;
 .legal_notice {
     padding-top: 15px;
 }
-.postPaymentButton {
-    width: 100%;
-    margin-top: 12px;
-    margin-bottom: 12px;
+.postPaymentConfirmation{
+    height: 180px;
 }
+
+.postPaymentContact {
+    height: 250px;
+    display: flex;
+    flex-direction: column;
+
+    form {
+    height: 140px;
+        display: flex;
+        flex-direction: column;
+    }
+    button {
+        width: 100%;
+        margin-top: auto;
+        margin-bottom: 12px;
+    }
+}
+
 .postPaymentText{
     @include fs-textSans(2);
 }
-.contactInformationTitle {
-    background-image: url('/assets/images/inline-svgs/share-email.svg');
-    background-repeat: no-repeat;
-    background-size: 20px;
-    padding-left: 25px;
 
-
-}
-.postPaymentTick{
+.circleBackground{
     width:40px;
     height:40px;
     background: white;
-    background-image: url('/assets/images/inline-svgs/tick.svg');
     border-radius: 1000px;
     background-repeat: no-repeat;
     background-size: 20px;
     background-position: center;
     margin-bottom: 12px;
 
+}
+.postPaymentTick{
+    background-image: url('/assets/images/inline-svgs/tick.svg');
+}
+.postPaymentEnvelope {
+    background-image: url('/assets/images/inline-svgs/share-email.svg');
 }
 .overlay {
     position: fixed;

--- a/assets/stylesheets/giraffe-react.scss
+++ b/assets/stylesheets/giraffe-react.scss
@@ -8,7 +8,8 @@ $control-spacing: 5px;
 .legal_notice {
     padding-top: 15px;
 }
-.postPaymentConfirmation{
+
+.postPaymentConfirmation {
     height: 180px;
 }
 
@@ -18,7 +19,7 @@ $control-spacing: 5px;
     flex-direction: column;
 
     form {
-    height: 140px;
+        height: 140px;
         display: flex;
         flex-direction: column;
     }
@@ -29,13 +30,13 @@ $control-spacing: 5px;
     }
 }
 
-.postPaymentText{
+.postPaymentText {
     @include fs-textSans(2);
 }
 
-.circleBackground{
-    width:40px;
-    height:40px;
+.circleBackground {
+    width: 40px;
+    height: 40px;
     background: white;
     border-radius: 1000px;
     background-repeat: no-repeat;
@@ -44,12 +45,15 @@ $control-spacing: 5px;
     margin-bottom: 12px;
 
 }
-.postPaymentTick{
+
+.postPaymentTick {
     background-image: url('/assets/images/inline-svgs/tick.svg');
 }
+
 .postPaymentEnvelope {
     background-image: url('/assets/images/inline-svgs/share-email.svg');
 }
+
 .overlay {
     position: fixed;
     display: flex;

--- a/assets/stylesheets/giraffe-react.scss
+++ b/assets/stylesheets/giraffe-react.scss
@@ -11,6 +11,30 @@ $control-spacing: 5px;
 .postPaymentButton {
     width: 100%;
     margin-top: 12px;
+    margin-bottom: 12px;
+}
+.postPaymentText{
+    font-size: 14px;
+}
+.contactInformationTitle {
+    background-image: url('/assets/images/inline-svgs/share-email.svg');
+    background-repeat: no-repeat;
+    background-size: 20px;
+    padding-left: 25px;
+
+
+}
+.postPaymentTick{
+    width:40px;
+    height:40px;
+    background: white;
+    background-image: url('/assets/images/inline-svgs/tick.svg');
+    border-radius: 1000px;
+    background-repeat: no-repeat;
+    background-size: 20px;
+    background-position: center;
+    margin-bottom: 12px;
+
 }
 .overlay {
     position: fixed;

--- a/assets/stylesheets/giraffe-react.scss
+++ b/assets/stylesheets/giraffe-react.scss
@@ -8,7 +8,10 @@ $control-spacing: 5px;
 .legal_notice {
     padding-top: 15px;
 }
-
+.postPaymentButton {
+    width: 100%;
+    margin-top: 12px;
+}
 .overlay {
     position: fixed;
     display: flex;

--- a/assets/stylesheets/giraffe-react.scss
+++ b/assets/stylesheets/giraffe-react.scss
@@ -10,16 +10,16 @@ $control-spacing: 5px;
 }
 
 .postPaymentConfirmation {
-    height: 180px;
+    height: 134px;
 }
 
 .postPaymentContact {
-    height: 250px;
+    height: 287px;
     display: flex;
     flex-direction: column;
 
     form {
-        height: 140px;
+        height: 177px;
         display: flex;
         flex-direction: column;
     }

--- a/assets/stylesheets/giraffe-react.scss
+++ b/assets/stylesheets/giraffe-react.scss
@@ -14,7 +14,7 @@ $control-spacing: 5px;
     margin-bottom: 12px;
 }
 .postPaymentText{
-    font-size: 14px;
+    @include fs-textSans(2);
 }
 .contactInformationTitle {
     background-image: url('/assets/images/inline-svgs/share-email.svg');

--- a/conf/routes
+++ b/conf/routes
@@ -18,7 +18,7 @@ POST           /paypal/auth                     controllers.PaypalController.aut
 
 GET            /paypal/:countryGroup/execute    controllers.PaypalController.executePayment(countryGroup: CountryGroup, paymentId, token, PayerID, CMP: Option[String], INTCMP: Option[String], ophanId: Option[String])
 POST           /paypal/hook                     controllers.PaypalController.hook
-
+POST           /:countryGroup/update-metadata   controllers.PaypalController.updateMetadata(countryGroup:CountryGroup)
 
 
 GET            /ca                              controllers.Giraffe.redirectToUk
@@ -27,6 +27,7 @@ GET            /int                             controllers.Giraffe.redirectToUk
 GET            /:countryGroup                   controllers.Giraffe.contribute(countryGroup: CountryGroup, error_code: Option[PaymentError]?=None)
 
 GET            /:countryGroup/thank-you         controllers.Giraffe.thanks(countryGroup: CountryGroup)
+GET            /:countryGroup/post-payment      controllers.Giraffe.postPayment(countryGroup: CountryGroup)
 
 POST           /pay                             controllers.Giraffe.pay
 


### PR DESCRIPTION
Added a post payment step when paying with PayPal that shows the option to sign in for marketing emails.

Some notes:
- The "post payment" page looks like the contribute page but it's a new page.All common parts have been extracted to a fragment named "contributionsMain" (worst name ever).
- To avoid any problems the post payment page will expect the email of the user to be in the play session. 
