### PR TITLE
fix for paypal error rendering with 6 amounts

### DIFF
--- a/assets/stylesheets/giraffe-react.scss
+++ b/assets/stylesheets/giraffe-react.scss
@@ -170,7 +170,7 @@ $control-spacing: 5px;
     margin-bottom: auto;
 
     @include mq(tablet) {
-        height: 350px;
+        min-height: 350px;
     }
 }
 


### PR DESCRIPTION
Just a  minor issue: when displaying 6 amounts paypal errors on the first page are rendered behind the buttons.

![6amountpaypalerror](https://cloud.githubusercontent.com/assets/15324270/18756947/b53b6ae8-80e9-11e6-8485-573b85bdfcae.jpg)
