### PR TITLE
Only allocate each user to one test

### DIFF
--- a/app/controllers/Giraffe.scala
+++ b/app/controllers/Giraffe.scala
@@ -129,13 +129,11 @@ class Giraffe(paymentServices: PaymentServices) extends Controller with Redirect
     val maxAmountInLocalCurrency = MaxAmount.forCurrency(countryGroup.currency)
     val creditCardExpiryYears = CreditCardExpiryYears(LocalDate.now.getYear, 10)
 
-    val inactiveTestsInCookies = request.cookies.filter(_.name.contains(Test.CookiePrefix))
-      .filterNot(c => c.value == variant.testSlug)
-      .flatMap(c => Test.allTests.find(_.slug.equalsIgnoreCase(c.name)))
+    val testsInCookies = request.cookies.filter(_.name.contains(Test.CookiePrefix)) map(_.name)
 
     Ok(views.html.giraffe.contribute(pageInfo, maxAmountInLocalCurrency, countryGroup, variant, cmp, intCmp, creditCardExpiryYears, errorMessage))
+      .discardingCookies(testsInCookies.toSeq map(DiscardingCookie(_)): _*)
       .withCookies(Test.testIdCookie(mvtId), Test.variantCookie(variant))
-      .discardingCookies(inactiveTestsInCookies.toSeq map (t => DiscardingCookie(Test.cookieName(t))): _*)
   }
 
   def thanks(countryGroup: CountryGroup) = NoCacheAction { implicit request =>

--- a/app/controllers/Giraffe.scala
+++ b/app/controllers/Giraffe.scala
@@ -128,10 +128,10 @@ class Giraffe(paymentServices: PaymentServices) extends Controller with Redirect
 
     val response = Ok(views.html.giraffe.contribute(pageInfo, maxAmountInLocalCurrency, countryGroup, variant, cmp, intCmp, creditCardExpiryYears, errorMessage))
 
-    val responseWithTests = (for {
-      testId <- request.cookies.get(Test.TestIdCookieName)
-      variantSlug <- request.cookies.get(Test.cookieName(variant))
-    } yield response) getOrElse response.withCookies(Test.testIdCookie(mvtId), Test.variantCookie(variant))
+    val responseWithTests = {
+      if (request.cookies.get(Test.TestIdCookieName).isDefined && request.cookies.get(Test.cookieName(variant)).isDefined) response
+      else response.withCookies(Test.testIdCookie(mvtId), Test.variantCookie(variant))
+    }
 
     responseWithTests.discardingCookies(Test.allTests.filterNot(t => t.slug == variant.testSlug) map(t => DiscardingCookie(Test.cookieName(t))): _*)
   }

--- a/app/controllers/Giraffe.scala
+++ b/app/controllers/Giraffe.scala
@@ -130,10 +130,10 @@ class Giraffe(paymentServices: PaymentServices) extends Controller with Redirect
 
     val responseWithTests = (for {
       testId <- request.cookies.get(Test.TestIdCookieName)
-      variantSlug <- request.cookies.get(Test.variantCookieName(variant))
+      variantSlug <- request.cookies.get(Test.cookieName(variant))
     } yield response) getOrElse response.withCookies(Test.testIdCookie(mvtId), Test.variantCookie(variant))
 
-    responseWithTests.discardingCookies(Test.allTests.filterNot(t => t.slug == variant.testSlug) map(t => DiscardingCookie(Test.testCookieName(t))): _*)
+    responseWithTests.discardingCookies(Test.allTests.filterNot(t => t.slug == variant.testSlug) map(t => DiscardingCookie(Test.cookieName(t))): _*)
   }
 
   def thanks(countryGroup: CountryGroup) = NoCacheAction { implicit request =>

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -45,7 +45,7 @@ class PaypalController(
 
     paypalService.executePayment(paymentId, payerId) match {
       case Right(_) =>
-        paypalService.storeMetaData(paymentId, variant, cmp, intCmp, ophanId, idUser) match {
+        paypalService.storeMetaData(paymentId, Seq(variant), cmp, intCmp, ophanId, idUser) match {
           case Right(savedData) => redirectWithCampaignCodes(postPayUrl).withSession(request.session + ("email" -> savedData.contributor.email))
           case Left(_) => redirectWithCampaignCodes(thanksUrl)
         }

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -120,7 +120,7 @@ class PaypalService(config: PaypalApiConfig, contributionData: ContributionData)
 
   def storeMetaData(
     paymentId: String,
-    variant: Variant,
+    variants: Seq[Variant],
     cmp: Option[String],
     intCmp: Option[String],
     ophanId: Option[String],
@@ -138,7 +138,7 @@ class PaypalService(config: PaypalApiConfig, contributionData: ContributionData)
         created = created,
         email = payerInfo.getEmail,
         ophanId = ophanId,
-        abTests = Json.toJson(variant),
+        abTests = Json.toJson(variants),
         cmp = cmp,
         intCmp = intCmp
       )

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -6,7 +6,7 @@ import com.gu.i18n.CountryGroup
 import com.netaporter.uri.Uri
 import com.paypal.api.payments._
 import com.paypal.base.Constants
-import com.paypal.base.rest.{APIContext}
+import com.paypal.base.rest.APIContext
 
 import scala.collection.JavaConverters._
 import com.typesafe.config.Config
@@ -14,7 +14,8 @@ import data.ContributionData
 import models.{ContributionMetaData, Contributor, PaymentHook}
 import org.joda.time.DateTime
 import play.api.Logger
-import views.support.ChosenVariants
+import play.api.libs.json.Json
+import views.support.Variant
 
 import scala.math.BigDecimal.RoundingMode
 import scala.util.{Failure, Success, Try}
@@ -119,7 +120,7 @@ class PaypalService(config: PaypalApiConfig, contributionData: ContributionData)
 
   def storeMetaData(
     paymentId: String,
-    chosenVariants: ChosenVariants,
+    variant: Variant,
     cmp: Option[String],
     intCmp: Option[String],
     ophanId: Option[String],
@@ -137,7 +138,7 @@ class PaypalService(config: PaypalApiConfig, contributionData: ContributionData)
         created = created,
         email = payerInfo.getEmail,
         ophanId = ophanId,
-        abTests = chosenVariants.asJson,
+        abTests = Json.toJson(variant),
         cmp = cmp,
         intCmp = intCmp
       )

--- a/app/views/fragments/giraffe/abFormTrack.scala.html
+++ b/app/views/fragments/giraffe/abFormTrack.scala.html
@@ -1,9 +1,0 @@
-@import views.support.ChosenVariants
-
-@(chosenVariants: ChosenVariants)
-
-
-<input type="hidden" name="abTest" class="js-ab-test" value="@chosenVariants.encodeURL">
-<script>
-    abTests = @Html(chosenVariants.asJson.toString);
-</script>

--- a/app/views/fragments/giraffe/contributionsMain.scala.html
+++ b/app/views/fragments/giraffe/contributionsMain.scala.html
@@ -1,15 +1,13 @@
 @import com.gu.i18n.CountryGroup
-@import views.support.ChosenVariants
 @import views.support.PageInfo
-@import views.support.Asset
 @import views.support.CountryGroupImplicits._
 
-@import play.api.libs.json.Json
 @(pageInfo: PageInfo = views.support.PageInfo(),
-countryGroup: CountryGroup,
-maxAmount: Option[Int] = None,
-mainScript: Option[String] = None,
-errorMessage:Option[String])(content: Html)
+    countryGroup: CountryGroup,
+    maxAmount: Option[Int] = None,
+    mainScript: Option[String] = None,
+    errorMessage:Option[String])(content: Html)
+
 @main(pageInfo, Some(countryGroup), maxAmount, mainScript) {
     <main class="giraffe__wrapper currency-@countryGroup.currency.toString.toLowerCase">
 

--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -1,17 +1,17 @@
 @import com.gu.i18n.CountryGroup
-@import views.support.ChosenVariants
 @import views.support.PageInfo
 @import fragments.giraffe.contributionsMain
 @import views.support.CountryGroupImplicits._
-
 @import play.api.libs.json.Json
-@(pageInfo: PageInfo, maxAmount: Int, countryGroup: CountryGroup, chosenVariants: ChosenVariants, cmpCode: Option[String], intCmpCode: Option[String], creditCardExpiryYears: List[Int], errorMessage: Option[String])
+@import views.support.Variant
+
+@(pageInfo: PageInfo, maxAmount: Int, countryGroup: CountryGroup, variant: Variant, cmpCode: Option[String], intCmpCode: Option[String], creditCardExpiryYears: List[Int], errorMessage: Option[String])
 
 @contributionsMain(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage) {
 
     <!-- react injects its components here -->
     <section id="contribute" class="contribute-container"
-    data-ab-tests="@Json.stringify(chosenVariants.asJson)"
+    data-ab-tests="@Json.stringify(Json.toJson(Seq(variant)))"
     data-country-group="@Json.stringify(Json.toJson(countryGroup))"
     data-max-amount="@maxAmount"
         @cmpCode.map(code => Html(s"""data-cmp-code="${code}""""))

--- a/app/views/support/ABTest.scala
+++ b/app/views/support/ABTest.scala
@@ -163,7 +163,7 @@ object Test {
     def pickByQueryStringOrCookie: Option[Variant] = {
       val search: Option[String] = request.getQueryString(test.slug)
         .orElse(request.cookies.get(s"$CookiePrefix.${test.slug}").map(_.value))
-      test.variantsByCountry(countryGroup).find(_.variantSlug == search.getOrElse(""))
+      test.variantsByCountry(countryGroup).find(v => search.contains(v.variantSlug))
     }
 
     pickByQueryStringOrCookie getOrElse pickRandomly

--- a/app/views/support/ABTest.scala
+++ b/app/views/support/ABTest.scala
@@ -160,7 +160,7 @@ object Test {
       test.variantRangesByCountry(countryGroup).dropWhile(_._1 < n).head._2
     }
 
-    def pickByQueryStringOrCookie[A]: Option[Variant] = {
+    def pickByQueryStringOrCookie: Option[Variant] = {
       val search: Option[String] = request.getQueryString(test.slug)
         .orElse(request.cookies.get(s"$CookiePrefix.${test.slug}").map(_.value))
       test.variantsByCountry(countryGroup).find(_.variantSlug == search.getOrElse(""))

--- a/app/views/support/ABTest.scala
+++ b/app/views/support/ABTest.scala
@@ -147,11 +147,12 @@ object Test {
 
   val allTests = List(AmountHighlightTest, PaymentMethodTest, RecurringPaymentTest)
 
+  def cookieName(v: Variant) = s"$CookiePrefix.${v.testSlug}"
+  def cookieName(t: TestTrait) = s"$CookiePrefix.${t.slug}"
+
   def testIdFor[A](request: Request[A]): Int = request.cookies.get(TestIdCookieName) map(_.value.toInt) getOrElse Random.nextInt(MaxTestId)
   def testIdCookie(id: Int) = Cookie(TestIdCookieName, id.toString, maxAge = Some(604800))
-  def variantCookie(v: Variant) = Cookie(variantCookieName(v), v.variantSlug, maxAge = Some(604800))
-  def variantCookieName(v: Variant) = s"$CookiePrefix.${v.testSlug}"
-  def testCookieName(t: TestTrait) = s"$CookiePrefix.${t.slug}"
+  def variantCookie(v: Variant) = Cookie(cookieName(v), v.variantSlug, maxAge = Some(604800))
 
   def pickVariant[A](countryGroup: CountryGroup, request: Request[A], test: TestTrait): Variant = {
     def pickRandomly: Variant = {

--- a/app/views/support/ABTest.scala
+++ b/app/views/support/ABTest.scala
@@ -119,7 +119,11 @@ object Test {
   def cookieName(v: Variant) = s"$CookiePrefix.${v.testSlug}"
   def cookieName(t: TestTrait) = s"$CookiePrefix.${t.slug}"
 
-  def testIdFor[A](request: Request[A]): Int = request.cookies.get(TestIdCookieName) map(_.value.toInt) getOrElse Random.nextInt(MaxTestId)
+  def testIdFor[A](request: Request[A]): Int = {
+    val id = request.cookies.get(TestIdCookieName) map(_.value.toInt) getOrElse Random.nextInt(MaxTestId)
+    if (id == 0) MaxTestId else id
+  }
+
   def testIdCookie(id: Int) = Cookie(TestIdCookieName, id.toString, maxAge = Some(604800))
   def variantCookie(v: Variant) = Cookie(cookieName(v), v.variantSlug, maxAge = Some(604800))
 

--- a/assets/javascripts/src/components/Main.jsx
+++ b/assets/javascripts/src/components/Main.jsx
@@ -118,11 +118,10 @@ class Main extends React.Component {
     }
 
     render() {
-
         const showSummary = !!this.props.card.amount && this.props.page !== PAGES.CONTRIBUTION;
         return <div>
             <MediaQuery query='(max-width: 740px)'>
-                {this.renderSummary(showSummary && !this.props.paymentMethodsTest.isControl())}
+                {this.renderSummary(showSummary && !(this.props.paymentMethodsTest && this.props.paymentMethodsTest.isControl()))}
                 <MobileWrapper submit={this.submit.bind(this, true)} componentFor={this.componentFor.bind(this)} {...this.props} />
             </MediaQuery>
 
@@ -132,8 +131,8 @@ class Main extends React.Component {
             </MediaQuery>
         </div>
     }
+
     renderSummary(visible) {
-        const showSummary = !!this.props.card.amount && this.props.page !== PAGES.CONTRIBUTION;
         return <AmountSummary currency={this.props.currency} amount={this.props.card.amount} visible={visible} />
     }
 }

--- a/assets/javascripts/src/components/Navigation.jsx
+++ b/assets/javascripts/src/components/Navigation.jsx
@@ -17,18 +17,18 @@ export default class Navigation extends React.Component {
     }
 
     render() {
-        const paymentMethods = this.props.paymentMethodsTest.paymentMethods;
-        const isPaymentMethodsControl = this.props.paymentMethodsTest.isControl();
-        const showForward = !this.props.processing && this.props.page == PAGES.DETAILS;
+        const paymentMethods = this.props.paymentMethodsTest && this.props.paymentMethodsTest.paymentMethods;
+        const isPaymentMethodsControl = this.props.paymentMethodsTest && this.props.paymentMethodsTest.isControl();
+
+        const showForward = !this.props.processing && this.props.page === PAGES.DETAILS;
         const showBack = !this.props.processing && this.props.page !== PAGES.CONTRIBUTION;
         const showPay = !this.props.processing && !!this.props.amount && this.props.page === PAGES.PAYMENT;
         const isFirstPage = !this.props.processing && this.props.page === PAGES.CONTRIBUTION;
-        const showMobileBack = !this.props.processing && this.props.page == PAGES.PAYMENT && !(isPaymentMethodsControl && this.props.mobile);
+        const showMobileBack = !this.props.processing && this.props.page === PAGES.PAYMENT && !(isPaymentMethodsControl && this.props.mobile);
 
-
-        const showPaypal = isFirstPage && paymentMethods.indexOf("PAYPAL") >= 0;
-        const showCard = isFirstPage && paymentMethods.indexOf("CARD") >= 0 && !(isPaymentMethodsControl && this.props.mobile);
-        const cardButtonLabel = isPaymentMethodsControl ? "Next" : "Contribute with debit/credit card";
+        const showPaypal = isFirstPage && paymentMethods && paymentMethods.indexOf("PAYPAL") >= 0;
+        const showCard = isFirstPage && (!paymentMethods || (paymentMethods && paymentMethods.indexOf("CARD") >= 0 && !(isPaymentMethodsControl && this.props.mobile)));
+        const cardButtonLabel = !paymentMethods || isPaymentMethodsControl ? "Next" : "Contribute with debit/credit card";
         const showProcessing = this.props.processing && !(this.props.page == PAGES.CONTRIBUTION && isPaymentMethodsControl);
 
         return <div className={'contribute-navigation ' + this.classNameFor(this.props.page)}>

--- a/assets/javascripts/src/modules/abTests.es6
+++ b/assets/javascripts/src/modules/abTests.es6
@@ -36,12 +36,15 @@ function testDataFor(tests, testName) {
 export function amounts(tests) {
     const data = testDataFor(tests, 'AmountHighlightTest');
     const defaultAmounts = [25, 50, 100, 250];
+
     return (data && data.values) || defaultAmounts;
 }
 
 export function paymentMethods(tests) {
-    return {
-        paymentMethods: testDataFor(tests, 'PaymentMethodTest').paymentMethods,
+    const data = testDataFor(tests, 'PaymentMethodTest');
+
+    if (data) return {
+        paymentMethods: data.paymentMethods,
         isControl: function () {
             return (this.paymentMethods.indexOf("CARD") >= 0 && this.paymentMethods.length == 1);
         }

--- a/assets/javascripts/src/modules/contribute.es6
+++ b/assets/javascripts/src/modules/contribute.es6
@@ -39,7 +39,7 @@ export function init() {
  * @returns {{abTests, maxAmount: number, countryGroup, currency}}
  */
 function appDataFrom(container) {
-    const { currency, ...countryGroup } = JSON.parse(container.getAttribute('data-country-group'))
+    const { currency, ...countryGroup } = JSON.parse(container.getAttribute('data-country-group'));
 
     return {
         abTests: JSON.parse(container.getAttribute('data-ab-tests')),

--- a/assets/javascripts/src/reducers/card.es6
+++ b/assets/javascripts/src/reducers/card.es6
@@ -15,7 +15,8 @@ export default function cardReducer(state = initialState, action) {
             return Object.assign({}, state, action.card);
 
         case SET_AMOUNT:
-            return Object.assign({}, state, { amount: formatCurrency(action.amount) });
+            const formatted = formatCurrency(action.amount);
+            return Object.assign({}, state, { amount: isNaN(formatted) ? 0 : formatted });
 
         default:
             return state;


### PR DESCRIPTION
This is an attempt to avoid test conflicts by never assigning more than one test to any user. It works like this...

for new users (no cookies):
1. assign user a random test ID, stored in a cookie
2. use that ID to select one of the currently active tests, and randomly pick a variant
3. store the result of that selection in a cookie

for returning users (test/variant cookies), their cookie is used to determine the test and variant, so people aren't reallocated on repeat visits.

When tests are deactivated (by removing them from the list of tests) the cookie associated with that test gets dropped 👋 

This could probably be tidied up/made much better so feel free to let loose in the comments.
