### PR TITLE
Remove the going to second step part of the amount test

### DIFF
--- a/assets/javascripts/src/modules/contribute.es6
+++ b/assets/javascripts/src/modules/contribute.es6
@@ -17,7 +17,6 @@ export function init() {
 
     if (presetAmount) {
         store.dispatch({ type: SET_AMOUNT, amount: parseInt(presetAmount) });
-        store.dispatch({ type: GO_FORWARD });
     }
 
     ReactDOM.render(


### PR DESCRIPTION
Previously, when the user came in from the contributions ask with the buttons, they were directed top the second step of the process. This is no longer a requirement.
