### PR TITLE
Add default amount values

### DIFF
--- a/assets/javascripts/src/modules/abTests.es6
+++ b/assets/javascripts/src/modules/abTests.es6
@@ -33,15 +33,24 @@ function testDataFor(tests, testName) {
     return test && test.data;
 }
 
+function countryId() {
+    try {
+        return store.getState().data.countryGroup.id;
+    } catch (e) {
+        return '';
+    }
+}
+
 export function amounts(tests) {
     const data = testDataFor(tests, 'AmountHighlightTest');
-    const defaultAmounts = [25, 50, 100, 250];
+    const defaults = countryId() === 'au' ? [50, 100, 250, 500] : [25, 50, 100, 250];
 
-    return (data && data.values) || defaultAmounts;
+    return (data && data.values) || defaults;
 }
 
 export function presetAmount(tests) {
     const data = testDataFor(tests, 'AmountHighlightTest');
+    const defaultAmount = countryId() === 'au' ? 100 : 25;
 
-    return data && data.preselect;
+    return (data && data.preselect) || defaultAmount;
 }


### PR DESCRIPTION
Now we only assign one test to users, they won't necessarily be in the `AmountHighlight` test.

We need default values for the amounts and which one to highlight outside of any A/B tests. This adds that (yeah, I know it's in a file called `abTests`...) 

@pvighi 
