### PR TITLE
Basic Auth

### DIFF
--- a/app/actions/BasicAuth.scala
+++ b/app/actions/BasicAuth.scala
@@ -1,0 +1,40 @@
+package actions
+
+import java.util.Base64
+
+import play.api.mvc.{Action, Request, Result, Results}
+
+import scala.concurrent.Future
+import scala.util.Try
+
+case class BasicAuth[A](user: String, password: String, realm: String = "Secured")(action: Action[A]) extends Action[A] {
+
+  lazy val parser = action.parser
+
+  def apply(request: Request[A]): Future[Result] = {
+    BasicAuth.parseAuthorisation(request) match {
+      case Some(creds) if creds.user == user && creds.password == password => action(request)
+      case _ => Future.successful(Results.Unauthorized.withHeaders("WWW-Authenticate" -> s"""Basic realm="$realm""""))
+    }
+  }
+}
+
+object BasicAuth {
+  case class Credentials(user: String, password: String)
+
+  def splitAuth(authString: String): Option[Credentials] = {
+    new String(authString).split(":").toList match {
+      case parsedUser :: parsedPassword :: Nil => Some(Credentials(parsedUser, parsedPassword))
+      case _ => None
+    }
+  }
+
+  def parseAuthorisation[A](request: Request[A]): Option[Credentials] = {
+    for {
+      header <- request.headers.get("Authorization")
+      encodedBlurb <- header.split(" ").drop(1).headOption
+      decodedBlurb <- Try(new String(Base64.getDecoder.decode(encodedBlurb))).toOption
+      credentials <- splitAuth(decodedBlurb)
+    } yield credentials
+  }
+}

--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -15,4 +15,7 @@ object CommonActions {
   private def resultModifier(f: Result => Result) = new ActionBuilder[Request] {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request).map(f)
   }
+
+  def BasicAuthAction[A](user: String, password: String)(action: Action[A]) = BasicAuth.apply(user, password)(action)
+
 }

--- a/conf/deploy.json
+++ b/conf/deploy.json
@@ -4,7 +4,8 @@
         "contributions-frontend":{
             "type":"autoscaling",
             "data":{
-                "bucket": "membership-dist"
+                "bucket": "membership-dist",
+                "publicReadAcl": false
             }
         }
     },

--- a/test/actions/BasicAuthSpec.scala
+++ b/test/actions/BasicAuthSpec.scala
@@ -1,0 +1,47 @@
+package actions
+
+import org.scalatest.MustMatchers
+import org.scalatestplus.play.PlaySpec
+import play.api.mvc._
+import play.api.test.Helpers._
+import play.api.test.FakeRequest
+
+import scala.concurrent.Future
+
+class BasicAuthSpec extends PlaySpec with MustMatchers with Results {
+
+  "The basic auth parser" must {
+    "return None when there's no authorisation" in {
+      val request = FakeRequest("", "")
+      BasicAuth.parseAuthorisation(request) mustBe None
+    }
+    "return parsed credentials when there's an authorization header" in {
+      val request = FakeRequest("", "").withHeaders("Authorization" -> "Basic dGVzdDoxMjM=")
+      BasicAuth.parseAuthorisation(request) mustBe Some(BasicAuth.Credentials("test", "123"))
+    }
+    "return None if the header is incorrect" in {
+      val request = FakeRequest("", "").withHeaders("Authorization" -> "Basic dGVzdDwq35MjM=")
+      BasicAuth.parseAuthorisation(request) mustBe None
+    }
+  }
+
+  private class DummyAction() extends Action[AnyContent]() {
+    override def parser: BodyParser[AnyContent] = BodyParsers.parse.default
+    override def apply(request: Request[AnyContent]): Future[Result] = Future.successful(Results.Ok)
+  }
+
+  "The basic auth action" must {
+    "return 401 with a special header if the endpoint needs to be authenticated" in {
+      val basicAuthAction = BasicAuth("test", "123")(new DummyAction)
+      val result = basicAuthAction.apply(FakeRequest("", ""))
+      status(result) mustBe 401
+      header("WWW-Authenticate", result) mustBe Some("""Basic realm="Secured"""")
+    }
+    "return 200 if valid header is passed" in {
+      val basicAuthAction = BasicAuth("test", "123")(new DummyAction)
+      val result = basicAuthAction.apply(FakeRequest("", "").withHeaders("Authorization" -> "Basic dGVzdDoxMjM="))
+      status(result) mustBe 200
+    }
+  }
+
+}


### PR DESCRIPTION
Basic Auth is going to be needed for stripe's webhooks.
This PR is an effort to make the webhook one look a bit smaller, as such it doesn't provide any change to the main logic, but just make a new feature available.

It also fixes the riff-raff deprecation warning we have during deployment
