### PR TITLE
be nicer when ga is blocked

### DIFF
--- a/assets/javascripts/src/modules/analytics/ga.es6
+++ b/assets/javascripts/src/modules/analytics/ga.es6
@@ -45,7 +45,7 @@ function create(){
 
 export function gaProxy() {
     const state = store.getState();
-    if (state.gaTracking.enabled) {
+    if (state.gaTracking.enabled && window.ga) {
         const allArgs = Array.from(arguments);
         allArgs[0] = defaultTracker + '.' + allArgs[0];
         window.ga.apply(window.ga, allArgs);


### PR DESCRIPTION
If the ga script is blocked I imagine the window.ga function won't be defined. This fix should fix a few of the errors we see in sentry.
