### PR TITLE
fix checkbox label clickability

### DIFF
--- a/app/views/giraffe/postPayment.scala.html
+++ b/app/views/giraffe/postPayment.scala.html
@@ -16,8 +16,8 @@
             <p class ="contribute-form__title">We would like to stay in touch</p>
             <form action="update-metadata" method="POST" >
                 <div class="giraffe-checkbox">
-                    <input type="checkbox" name="marketingOptIn" checked="true" value="true"/>
-                    <label htmlFor="marketingOptIn">Keep me informed with updates and offers from the Guardian</label>
+                    <input id="marketingOptIn" type="checkbox" name="marketingOptIn" checked="true" value="true"/>
+                    <label for="marketingOptIn">Keep me informed with updates and offers from the Guardian</label>
                 </div>
                 <button class="action action--button action--button--forward action action--button contribute-navigation__next action--next">
                     <span>Next</span>


### PR DESCRIPTION
we can't click on the label to uncheck the checkbox right now, which require the user to be super precise with its mouse.

This PR fixes it.
