### PR TITLE
We should use INTCMP to track redirections between Guardian propertie…

### DIFF
--- a/assets/javascripts/src/components/tests/RecurringNotification.jsx
+++ b/assets/javascripts/src/components/tests/RecurringNotification.jsx
@@ -10,7 +10,7 @@ export default class RecurringNotification extends React.Component {
                 <h2 className="contribute-form__title">Thank you for your interest in monthly contributions</h2>
 
                 <p>At the moment we can only accept one-time contributions, but we’re gauging interest in recurring payments.</p>
-                <p>In the meantime, why not <a href="https://membership.theguardian.com/supporter?CMP=recurring_contribution" target="_blank">become a supporter</a>?</p>
+                <p>In the meantime, why not <a href="https://membership.theguardian.com/supporter?INTCMP=recurring_contribution" target="_blank">become a supporter</a>?</p>
 
                 <Button className="action action--button contribute-navigation__next"
                         onClick={this.props.dismiss}


### PR DESCRIPTION
We should use INTCMP to track redirections between Guardian properties, not CMP - which is for externally-driven marketing campaigns.

cc @ajosephides please correct me if I'm wrong?
cc @AWare @desbo 
