### PR TITLE
[WIP] Initial code that will eventually let us send emails.

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -13,6 +13,7 @@ object Config {
   val contributeUrl = config.getString("contribute.url")
   val facebookAppId = config.getString("facebook.app.id")
   val idWebAppUrl = config.getString("identity.webapp.url")
+  val emailSQSQueue = config.getString("emailSQSQueue")
 
   val stage = config.getString("stage")
   val stageProd: Boolean = stage == "PROD"

--- a/app/models/ContributorRow.scala
+++ b/app/models/ContributorRow.scala
@@ -1,0 +1,65 @@
+package model.exactTarget
+
+import cats.data.{Xor, XorT}
+import com.gu.exacttarget.DataExtension
+import com.paypal.api.payments.Payment
+import com.paypal.base.rest.APIContext
+import models.{PaypalHook, StripeHook}
+import org.joda.time.DateTime
+import play.api.libs.json.{JsValue, Json, Writes}
+
+import scala.concurrent.Future
+
+
+
+object ContributorRow {
+  def fromStripe(stripeHook: StripeHook): ContributorRow = {
+
+    ContributorRow(
+      stripeHook.email,
+      stripeHook.created,
+      stripeHook.amount,
+      stripeHook.currency,
+      stripeHook.name,
+      Some(stripeHook.cardCountry)
+    ))
+
+  }
+//TODO: move these calls to the paypal service
+  def fromPaypal(paypalHook: PaypalHook)(implicit apiContext: APIContext): XorT[Future, Throwable, ContributorRow] = {
+    for {
+      payment <- Xor.catchNonFatal(Payment.get(apiContext, paypalHook.paymentId))
+      created <- Xor.catchNonFatal(new DateTime(payment.getCreateTime))
+      payerInfo <- Xor.catchNonFatal(payment.getPayer.getPayerInfo)
+    } yield {
+      Xor.right(ContributorRow(payerInfo.getEmail, created, paypalHook.amount, paypalHook.currency, Seq(payerInfo.getFirstName, payerInfo.getMiddleName, payerInfo.getLastName).mkString(" ")))
+    }
+  }
+}
+
+case class ContributorRow(email: String, created: DateTime, amount: BigDecimal, currency: String, name: String, cardCountry: Option[String] = None) {
+  def forExtension: DataExtension = ??? //TODO: We need to find out what DataExtension we want and add it to membership-common
+
+  implicit val contributorRowWriter = new Writes[ContributorRow] {
+    def writes(c: ContributorRow): JsValue = Json.obj(
+      "To" -> Json.obj(
+        "Address" -> c.email,
+        "SubscriberKey" -> c.email, //this looks weird, but ExactTarget performs a self join
+        "ContactAttributes" -> Json.obj(
+          "SubscriberAttributes" -> Json.obj(
+            "created" -> created.toString, //TODO: format this date (what does extact target need)
+            "amount" -> amount,
+            "currency" -> currency,
+            "name" -> name
+          )
+        ),
+        "DataExtensionName" -> forExtension.name
+      )
+    )
+  }
+}
+
+
+
+
+

--- a/app/models/PaymentHook.scala
+++ b/app/models/PaymentHook.scala
@@ -125,7 +125,8 @@ object PaypalHook {
 }
 
 case class StripeHook(
-  contributionId: ContributionId,
+                       name: String,
+                       contributionId: ContributionId,
   eventId: String,
   paymentId: String,
   balanceTransactionId: String,
@@ -153,10 +154,12 @@ object StripeHook {
         amount <- (payload \ "amount").validate[Long]
         cardCountry <- (payload \ "source" \ "country").validate[String]
         status <- (payload \ "status").validate[PaymentStatus](PaymentStatus.stripeReads)
+        name <- (metadata \ "name").validate[String]
         email <- (metadata \ "email").validate[String]
         balanceTransactionId <- (payload \ "balance_transaction").validate[String]
       } yield {
         StripeHook(
+          name = name,
           contributionId = contributionId,
           eventId = eventId,
           paymentId = paymentId,

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -1,0 +1,49 @@
+package services
+
+import cats.data.{Xor, XorT}
+import com.amazonaws.auth._
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.typesafe.scalalogging.LazyLogging
+import com.amazonaws.regions.{Region, Regions}
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import com.amazonaws.services.sqs.AmazonSQSClient
+import com.amazonaws.services.sqs.model._
+import configuration.Config
+import data.ContributionData
+import model.exactTarget.ContributorRow
+import play.api.libs.json._
+
+import scala.concurrent.Future
+import scala.util.Try
+
+object EmailService extends LazyLogging {
+  def thank(row: ContributorRow): XorT[Future, Throwable, SendMessageResult] = {
+    val queue = Config.emailSQSQueue
+    sendEmailToQueue(queue, row) //Todo: log if failed
+
+  }
+
+  val credentialsProviderChain: AWSCredentialsProviderChain =
+    new AWSCredentialsProviderChain(
+      new EnvironmentVariableCredentialsProvider,
+      new SystemPropertiesCredentialsProvider,
+      new ProfileCredentialsProvider("membership"),
+      new InstanceProfileCredentialsProvider
+    )
+  private val sqsClient = new AmazonSQSClient(credentialsProviderChain)
+  sqsClient.setRegion(Region.getRegion(Regions.EU_WEST_1))
+
+
+  def sendEmailToQueue(queueName: String, row: ContributorRow) :XorT[Future,Throwable,SendMessageResult] = {
+    Future {
+      val payload = Json.toJson(row).toString
+      def send(msg: String) = {
+        val queueUrl = sqsClient.createQueue(new CreateQueueRequest(queueName)).getQueueUrl
+        sqsClient.sendMessage(new SendMessageRequest(queueUrl, msg))
+      }
+      Xor.catchNonFatal(
+        send(payload)
+      )
+    }
+  }
+}

--- a/app/services/StripeService.scala
+++ b/app/services/StripeService.scala
@@ -76,6 +76,12 @@ class StripeService(apiConfig: StripeApiConfig, metrics: StatusMetrics, contribu
       )
     }
 
+    println(stripeHook.amount)
+    println(stripeHook.created)
+    println(stripeHook.cardCountry)
+    println(stripeHook.email)
+    println(stripeHook.currency)
+
     for {
       eventFromStripe <- findCharge(stripeHook)
       balanceTransaction <- findBalanceTransaction(eventFromStripe)

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,8 @@ val anormLib = "com.typesafe.play" %% "anorm" % "2.5.2"
 val postgresql = "org.postgresql" % "postgresql" % "9.4.1209"
 val identityCookie =  "com.gu.identity" %% "identity-cookie" % "3.51"
 val scalaTest = "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test
+val sqs = "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.36"
+
 libraryDependencies ++= Seq(
     cache,
     ws,
@@ -55,7 +57,8 @@ libraryDependencies ++= Seq(
     macwire,
     anormLib,
     postgresql,
-    identityCookie
+    identityCookie,
+    sqs
 )
 dependencyOverrides += "com.typesafe.play" %% "play-json" % "2.4.6"
 

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -7,6 +7,8 @@
 
 stage="DEV"
 
+emailSQSQueue="contributions-thanks-dev"
+
 stripe {
     default=TEST
     testing=TEST

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -7,6 +7,8 @@
 
 stage="PROD"
 
+emailSQSQueue="contributions-thanks"
+
 stripe {
     default=LIVE
     testing=TEST


### PR DESCRIPTION
🚨🚨 **THIS IS WORK IN PROGRESS AND IS BEING HANDED OVER DO NOT MERGE**🚨🚨

To send an email we need to:
- build the JSON enevlope to send to exact target
- add this to an SQS queue
- tell membership workflow about this queue

This commit makes way to 1 and 2.

The JSON that Exact Target requires needs to include:
- email
- creation date (a date time that will need  some formatting)
- amount
- card country (I presently am sending currency instead, we'll need to discuss this and get it changed to currency)
- name
- data extension (this is the name of the custom fieldset in exacttarget that we're using, if you located it, you can change membership common to add it like the others in their)

This is all straightforward with Stripe, but paypal needs an additional call to get the name and email.

Membership Workflow sends the final email; and this will need to know about the SQS queue and where in exacttarget to send it.

Other fun: To add the data extension to exacttarget, we'll need to update membership common. It's quite a jump, but I checked with Tom and he doesn't think he's changed anything we use.
