### PR TITLE
Fix complete events

### DIFF
--- a/assets/javascripts/src/modules/abTests.es6
+++ b/assets/javascripts/src/modules/abTests.es6
@@ -27,7 +27,7 @@ function abTestData(tests, complete) {
     for (var test of tests) {
         data[test.testSlug] = {
             'variantName': test.variantSlug,
-            'complete': complete
+            'complete': String(complete)
         }
     }
 


### PR DESCRIPTION
The `complete` property needs to be sent as a string.
