### PR TITLE
Store Ophan browser ID as well as pageview ID

### DIFF
--- a/app/controllers/Giraffe.scala
+++ b/app/controllers/Giraffe.scala
@@ -54,7 +54,8 @@ class Giraffe(paymentServices: PaymentServices, addToken: CSRFAddToken) extends 
                           marketing: Boolean,
                           postcode: Option[String],
                           abTests: Set[JsonAbTest],
-                          ophanId: String,
+                          ophanPageviewId: String,
+                          ophanBrowserId: String,
                           cmp: Option[String],
                           intcmp: Option[String]
 
@@ -75,7 +76,8 @@ class Giraffe(paymentServices: PaymentServices, addToken: CSRFAddToken) extends 
         "variantName" -> text,
         "variantSlug" -> text
       )(JsonAbTest.apply)(JsonAbTest.unapply)),
-      "ophanId" -> text,
+      "ophanPageviewId" -> text,
+      "ophanBrowserId" -> text,
       "cmp" -> optional(text),
       "intcmp" -> optional(text)
     )(SupportForm.apply)(SupportForm.unapply)
@@ -183,7 +185,8 @@ class Giraffe(paymentServices: PaymentServices, addToken: CSRFAddToken) extends 
       "email" -> form.email,
       "name" -> form.name,
       "abTests" -> Json.toJson(Seq(variant)).toString,
-      "ophanId" -> form.ophanId,
+      "ophanPageviewId" -> form.ophanPageviewId,
+      "ophanBrowserId" -> form.ophanBrowserId,
       "cmp" -> form.cmp.mkString,
       "intcmp" -> form.intcmp.mkString,
       "contributionId" -> contributionId.toString
@@ -213,7 +216,8 @@ class Giraffe(paymentServices: PaymentServices, addToken: CSRFAddToken) extends 
         variants = Seq(variant),
         cmp = form.cmp,
         intCmp = form.intcmp,
-        ophanId = form.ophanId,
+        ophanPageviewId = form.ophanPageviewId,
+        ophanBrowserId = form.ophanBrowserId,
         idUser = idUser
       )
     }

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -30,7 +30,8 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
     payerId: String,
     cmp: Option[String],
     intCmp: Option[String],
-    ophanId: Option[String]
+    ophanPageviewId: Option[String],
+    ophanBrowserId: Option[String]
   ) = NoCacheAction.async { implicit request =>
     val mvtId = Test.testIdFor(request)
 
@@ -40,7 +41,7 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
     val paypalService = paymentServices.paypalServiceFor(request)
     val idUser = IdentityId.fromRequest(request)
 
-    def saveMetadata = paypalService.storeMetaData(paymentId, Seq(variant), cmp, intCmp, ophanId, idUser).value.map {
+    def saveMetadata = paypalService.storeMetaData(paymentId, Seq(variant), cmp, intCmp, ophanPageviewId, ophanBrowserId, idUser).value.map {
       case Xor.Right(savedData) => redirectWithCampaignCodes(postPayUrl).withSession(request.session + ("email" -> savedData.contributor.email))
       case Xor.Left(_) => redirectWithCampaignCodes(thanksUrl)
     }

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -58,7 +58,8 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
     amount: BigDecimal,
     cmp: Option[String],
     intCmp: Option[String],
-    ophanId: Option[String]
+    ophanPageviewId: Option[String],
+    ophanBrowserId: Option[String]
   )
 
   object AuthRequest {
@@ -67,7 +68,8 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
         (__ \ "amount").read(min[BigDecimal](1)) and
         (__ \ "cmp").readNullable[String] and
         (__ \ "intCmp").readNullable[String] and
-        (__ \ "ophanId").readNullable[String]
+        (__ \ "ophanPageviewId").readNullable[String] and
+        (__ \ "ophanBrowserId").readNullable[String]
       ) (AuthRequest.apply _)
   }
 
@@ -100,7 +102,8 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
             contributionId = ContributionId.random,
             cmp = authRequest.cmp,
             intCmp = authRequest.intCmp,
-            ophanId = authRequest.ophanId
+            ophanPageviewId = authRequest.ophanPageviewId,
+            ophanBrowserId = authRequest.ophanBrowserId
           )
           authResponse.value map {
             case Xor.Right(url) => Ok(Json.toJson(AuthResponse(url)))

--- a/app/data/ContributionData.scala
+++ b/app/data/ContributionData.scala
@@ -71,7 +71,8 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) {
           contributionid,
           created,
           email,
-          ophanid,
+          ophan_pageview_id,
+          ophan_browser_id,
           abtests,
           cmp,
           intcmp
@@ -79,7 +80,8 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) {
           ${pmd.contributionId.id}::uuid,
           ${pmd.created},
           ${pmd.email},
-          ${pmd.ophanId},
+          ${pmd.ophanPageviewId},
+          ${pmd.ophanBrowserId},
           ${pmd.abTests},
           ${pmd.cmp},
           ${pmd.intCmp}
@@ -88,7 +90,8 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) {
           contributionid = excluded.contributionid,
           created = excluded.created,
           email = excluded.email,
-          ophanid = excluded.ophanid,
+          ophan_pageview_id = excluded.ophan_pageview_id,
+          ophan_browser_id = excluded.ophan_browser_id,
           abtests = excluded.abtests,
           cmp = excluded.cmp,
           intcmp = excluded.intcmp"""

--- a/app/models/ContributionMetaData.scala
+++ b/app/models/ContributionMetaData.scala
@@ -7,7 +7,8 @@ case class ContributionMetaData(
   contributionId: ContributionId,
   created: DateTime,
   email: String,
-  ophanId: Option[String],
+  ophanPageviewId: Option[String],
+  ophanBrowserId: Option[String],
   abTests: JsValue,
   cmp: Option[String],
   intCmp: Option[String]

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -148,7 +148,8 @@ class PaypalService(
     variants: Seq[Variant],
     cmp: Option[String],
     intCmp: Option[String],
-    ophanId: Option[String],
+    ophanPageviewId: Option[String],
+    ophanBrowserId: Option[String],
     idUser: Option[IdentityId]
   ): XorT[Future, String, SavedContributionData] = {
 
@@ -170,7 +171,8 @@ class PaypalService(
         contributionId = ContributionId(contributionId),
         created = created,
         email = payerInfo.getEmail,
-        ophanId = ophanId,
+        ophanPageviewId = ophanPageviewId,
+        ophanBrowserId = ophanBrowserId,
         abTests = Json.toJson(variants),
         cmp = cmp,
         intCmp = intCmp

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -77,7 +77,8 @@ class PaypalService(
     contributionId: ContributionId,
     cmp: Option[String],
     intCmp: Option[String],
-    ophanId: Option[String]
+    ophanPageviewId: Option[String],
+    ophanBrowserId: Option[String]
   ): XorT[Future, String, Uri] = {
 
     val paymentToCreate = {
@@ -86,7 +87,8 @@ class PaypalService(
         val extraParams = List(
           cmp.map(value => s"CMP=$value"),
           intCmp.map(value => s"INTCMP=$value"),
-          ophanId.map(value => s"ophanId=$value")
+          ophanPageviewId.map(value => s"pvid=$value"),
+          ophanBrowserId.map(value => s"bid=$value")
         ).flatten match {
           case Nil => ""
           case params => params.mkString("?", "&", "")

--- a/app/services/StripeService.scala
+++ b/app/services/StripeService.scala
@@ -33,7 +33,8 @@ class StripeService(
     variants: Seq[Variant],
     cmp: Option[String],
     intCmp: Option[String],
-    ophanId: String,
+    ophanPageviewId: String,
+    ophanBrowserId: String,
     idUser: Option[IdentityId]
   ): XorT[Future, String, SavedContributionData] = {
 
@@ -46,7 +47,8 @@ class StripeService(
       contributionId = contributionId,
       created = created,
       email = email,
-      ophanId = Some(ophanId),
+      ophanPageviewId = Some(ophanPageviewId),
+      ophanBrowserId = Some(ophanBrowserId),
       abTests = Json.toJson(variants),
       cmp = cmp,
       intCmp = intCmp

--- a/assets/javascripts/src/actions.es6
+++ b/assets/javascripts/src/actions.es6
@@ -64,7 +64,8 @@ export function paypalRedirect(dispatch) {
         amount: state.card.amount, //TODO should the amount be somewhere else rather than in the card section?,
         cmp: state.data.cmpCode,
         intCmp: state.data.intCmpCode,
-        ophanId: state.data.ophanId
+        ophanPageviewId: state.data.ophan.pageviewId,
+        ophanBrowserId: state.data.ophan.browserId
     };
 
     const url = '/paypal/auth?csrfToken=' + state.data.csrfToken;

--- a/assets/javascripts/src/actions.es6
+++ b/assets/javascripts/src/actions.es6
@@ -120,7 +120,8 @@ function paymentFormData(state, token) {
         marketing: state.details.optIn,
         postcode: state.details.postcode,
         abTests: state.data.abTests,
-        ophanId: state.data.ophanId,
+        ophanPageviewId: state.data.ophan.pageviewId,
+        ophanBrowserId: state.data.ophan.browserId,
         cmp: state.data.cmpCode,
         intcmp: state.data.intCmpCode
     };

--- a/assets/javascripts/src/modules/analytics/ophan.es6
+++ b/assets/javascripts/src/modules/analytics/ophan.es6
@@ -1,10 +1,15 @@
 import raven from 'src/modules/raven';
+import {getCookie} from 'src/utils/cookie';
 
-var ophanUrl = '//j.ophan.co.uk/contribution.js';
-var ophan = curl(ophanUrl);
+const ophanUrl = '//j.ophan.co.uk/contribution.js';
+const ophan = curl(ophanUrl);
 
-export var loaded = ophan;
+export const loaded = ophan;
 
 export function init() {
     return ophan.then(null, raven.Raven.captureException);
+}
+
+export function browserId() {
+    return getCookie('bwid');
 }

--- a/assets/javascripts/src/modules/contribute.es6
+++ b/assets/javascripts/src/modules/contribute.es6
@@ -9,6 +9,7 @@ import { SET_DATA, SET_COUNTRY_GROUP, SET_AMOUNT, GO_FORWARD } from 'src/actions
 import { attachCurrencyListeners, attachErrorDialogListener } from 'src/modules/domListeners';
 import * as ophan from 'src/modules/analytics/ophan';
 
+
 export function init() {
     const container = document.getElementById('contribute');
     const presetAmount = getUrlParameter('amount');
@@ -28,7 +29,7 @@ export function init() {
 
     attachCurrencyListeners();
     attachErrorDialogListener();
-    setOphanId();
+    setOphanIds();
 }
 
 /**
@@ -62,9 +63,12 @@ function getUrlParameter(rawName, url) {
     return decodeURIComponent(results[2].replace(/\+/g, " "));
 }
 
-function setOphanId() {
+function setOphanIds() {
     ophan.loaded.then(o => store.dispatch({
         type: SET_DATA,
-        data: { ophanId: o.viewId }
+        data: { ophan: {
+            pageviewId: o.viewId,
+            browserId: ophan.browserId()
+        }}
     }));
 }

--- a/assets/javascripts/src/reducers/data.es6
+++ b/assets/javascripts/src/reducers/data.es6
@@ -12,7 +12,10 @@ const initialState = {
     },
     cmpCode: '',
     intCmpCode: '',
-    ophanId: null
+    ophan: {
+        pageviewId: null,
+        browserId: null
+    }
 };
 
 /**

--- a/conf/routes
+++ b/conf/routes
@@ -16,7 +16,7 @@ GET            /home                            controllers.Giraffe.contributeRe
 GET            /healthcheck                     controllers.Healthcheck.healthcheck
 POST           /paypal/auth                     controllers.PaypalController.authorize
 
-GET            /paypal/:countryGroup/execute    controllers.PaypalController.executePayment(countryGroup: CountryGroup, paymentId, token, PayerID, CMP: Option[String], INTCMP: Option[String], ophanId: Option[String])
+GET            /paypal/:countryGroup/execute    controllers.PaypalController.executePayment(countryGroup: CountryGroup, paymentId, token, PayerID, CMP: Option[String], INTCMP: Option[String], ophanPageviewId: Option[String], ophanBrowserId: Option[String])
 POST           /paypal/hook                     controllers.PaypalController.hook
 POST           /stripe/hook                     controllers.StripeController.hook
 POST           /:countryGroup/update-metadata   controllers.PaypalController.updateMetadata(countryGroup:CountryGroup)


### PR DESCRIPTION
We need to start storing browser IDs as well as pageview IDs (which are currently stored in the `ophanid` column in `contribution_metadata`). These are the changes required to the code to add them to the metadata, there's also a bit to do at the database side:
1. create new columns in the `contribution_metadata` table: `ophan_pageview_id` and `ophan_browser_id`
2. update the `all_payments` view to coalesce `metadata.ophanid` and `metadata.ophan_pageview_id` 
3. release this code, which will start writing IDs to the two new columns
4. move all of the old values from `ophanid` to `ophan_pageview_id`
5. delete the `ophanid` column

@alexduf does this look alright? 
