### PR TITLE
Don't send automatic email for some CMP

### DIFF
--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -142,7 +142,9 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
         intCmp = form.intcmp,
         ophanPageviewId = form.ophanPageviewId,
         ophanBrowserId = form.ophanBrowserId,
-        idUser = idUser
+        idUser = idUser,
+        amount = BigDecimal(charge.amount, 2),
+        currency = charge.currency.toUpperCase
       )
     }
 

--- a/app/models/ContributorRow.scala
+++ b/app/models/ContributorRow.scala
@@ -10,7 +10,8 @@ case class ContributorRow(
   created: DateTime,
   amount: BigDecimal,
   currency: String,
-  name: String
+  name: String,
+  cmp: Option[String]
 ) {
   def edition: String = currency match {
     case "GBP" => "uk"

--- a/app/models/ContributorRow.scala
+++ b/app/models/ContributorRow.scala
@@ -10,38 +10,17 @@ case class ContributorRow(
   created: DateTime,
   amount: BigDecimal,
   currency: String,
-  edition: String,
-  name: String,
-  cardCountry: Option[String] = None
-)
-
-object ContributorRow {
-
-  def currencyToEdition(currency: String): String = currency match {
+  name: String
+) {
+  def edition: String = currency match {
     case "GBP" => "uk"
     case "USD" => "us"
     case "AUD" => "au"
     case _ => "international"
   }
+}
 
-  def fromStripe(stripeHook: StripeHook): ContributorRow = ContributorRow(
-    email = stripeHook.email,
-    created = stripeHook.created,
-    amount = stripeHook.amount,
-    currency = stripeHook.currency,
-    edition = currencyToEdition(stripeHook.currency),
-    name = stripeHook.name,
-    cardCountry = Some(stripeHook.cardCountry)
-  )
-
-  def fromPaypal(paypalHook: PaypalHook, name: String, email: String): ContributorRow = ContributorRow(
-    email = email,
-    created = paypalHook.created,
-    amount = paypalHook.amount,
-    currency = paypalHook.currency,
-    edition = currencyToEdition(paypalHook.currency),
-    name = name
-  )
+object ContributorRow {
 
   implicit val contributorRowWriter = new Writes[ContributorRow] {
     def writes(c: ContributorRow): JsValue = Json.obj(

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -32,7 +32,7 @@ class EmailService(implicit ec: ExecutionContext) extends LazyLogging {
 
   // these are campaign codes use to ask people to contribute again.
   // We don't want to send them an automatic email yet
-  val noEmailCampaignCodes = Set("ema_cns_a", "ema_cns_b")
+  val noEmailCampaignCodes = Set("co_uk_ema_cns_a", "co_uk_ema_cns_b")
 
   def thank(row: ContributorRow): XorT[Future, Throwable, SendMessageResult] = {
     if (noEmailCampaignCodes.exists(row.cmp.contains)) {

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -1,6 +1,7 @@
 package services
 
 import cats.data.{Xor, XorT}
+import cats.implicits._
 import com.amazonaws.auth._
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.typesafe.scalalogging.LazyLogging
@@ -29,8 +30,16 @@ class EmailService(implicit ec: ExecutionContext) extends LazyLogging {
 
   val thankYouQueueUrl = sqsClient.getQueueUrl(Config.thankYouEmailQueue).getQueueUrl
 
+  // these are campaign codes use to ask people to contribute again.
+  // We don't want to send them an automatic email yet
+  val noEmailCampaignCodes = Set("ema_cns_a", "ema_cns_b")
+
   def thank(row: ContributorRow): XorT[Future, Throwable, SendMessageResult] = {
-    sendEmailToQueue(thankYouQueueUrl, row)
+    if (noEmailCampaignCodes.exists(row.cmp.contains)) {
+      XorT.pure[Future, Throwable, SendMessageResult](new SendMessageResult)
+    } else {
+      sendEmailToQueue(thankYouQueueUrl, row)
+    }
   }
 
   def sendEmailToQueue(queueUrl: String, row: ContributorRow): XorT[Future, Throwable, SendMessageResult] = {

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -206,7 +206,8 @@ class PaypalService(
         created = created,
         amount = BigDecimal(transaction.getAmount.getTotal),
         currency = transaction.getAmount.getCurrency,
-        name = fullName(payerInfo).getOrElse("")
+        name = fullName(payerInfo).getOrElse(""),
+        cmp = cmp
       )
 
       (contributor, metadata, contributorRow)

--- a/app/services/StripeService.scala
+++ b/app/services/StripeService.scala
@@ -49,7 +49,8 @@ class StripeService(
       created = created,
       amount = amount,
       currency = currency,
-      name = name
+      name = name,
+      cmp = cmp
     ))
 
     val metadata = ContributionMetaData(


### PR DESCRIPTION
When a user comes back to the contribution website we don't want to send the same automatic email that was sent the first time.
This PR includes a change that moves when the email is sent in the workflow.
It is now sent when we save the metadata as it happen when: we know the user has paid, and we know the user's CMP code.
