### PR TITLE
Don't parse "name" as we don't use it anymore

### DIFF
--- a/app/models/PaymentHook.scala
+++ b/app/models/PaymentHook.scala
@@ -128,7 +128,6 @@ case class StripeHook(
   amount: BigDecimal,
   cardCountry: String,
   status: PaymentStatus,
-  name: String,
   email: String
 )
 
@@ -147,7 +146,6 @@ object StripeHook {
         amount <- (payload \ "amount").validate[Long]
         cardCountry <- (payload \ "source" \ "country").validate[String]
         status <- (payload \ "status").validate[PaymentStatus](PaymentStatus.stripeReads)
-        name <- (metadata \ "name").validate[String]
         email <- (metadata \ "email").validate[String]
       } yield {
         StripeHook(
@@ -160,7 +158,6 @@ object StripeHook {
           amount = BigDecimal(amount, 2),
           cardCountry = cardCountry,
           status = status,
-          name = name,
           email = email
         )
       }

--- a/test/models/PaymentHookSpec.scala
+++ b/test/models/PaymentHookSpec.scala
@@ -61,7 +61,6 @@ class PaymentHookSpec extends WordSpec with MustMatchers {
         amount = BigDecimal("25.00"),
         cardCountry = "US",
         status = Paid,
-        name = "a",
         email = "a@a.a"
       )
     }
@@ -176,7 +175,6 @@ class PaymentHookSpec extends WordSpec with MustMatchers {
                           |        "ophanId": "it4m6aomfvm3rlv0o1ov",
                           |        "abTests": "[{\"testName\":\"AmountHighlightTest\",\"testSlug\":\"highlight\",\"variantName\":\"Amount - 50 highlight\",\"variantSlug\":\"50\"},{\"testName\":\"MessageCopyTest\",\"testSlug\":\"mcopy\",\"variantName\":\"Copy - control\",\"variantSlug\":\"control\"},{\"testName\":\"PaymentMethodTest\",\"testSlug\":\"paymentMethods\",\"variantName\":\"Paypal\",\"variantSlug\":\"paypal\"}]",
                           |        "email": "a@a.a",
-                          |        "name": "a",
                           |        "idUser": "123",
                           |        "contributionId": "7f5256d2-8e63-4b29-8f1e-f5c4e670db22"
                           |      },


### PR DESCRIPTION
Following the two steps tests, our hooks weren't containing the `name` field in their metadata. We didn't catch that it was causing the stripe hook to fail.

Following this morning's PR where I moved the email to be sent earlier, we don't need to parse the name anymore.

This fix remove the parsing of the name and therefore fixes the webhook processing
