### PR TITLE
debugging GA events not firing

### DIFF
--- a/assets/javascripts/src/modules/abTests.es6
+++ b/assets/javascripts/src/modules/abTests.es6
@@ -53,7 +53,7 @@ function completeAARecurringTestIfApplicable(tests) {
 
     if (targetTest !== undefined) {
         registerTestWithOphan(targetTest, true);
-        GA.event('no-object', 'pageview', 'aa-recurring-test');
+        GA.waitForGA().then(_ => GA.event('Test', 'NoAction', 'AARecurringTest'));
     }
 }
 

--- a/assets/javascripts/src/modules/analytics/ga.es6
+++ b/assets/javascripts/src/modules/analytics/ga.es6
@@ -114,7 +114,6 @@ export function pageView() {
     });
 }
 
-
 /**
  * @returns {Promise} a Promise that will resolved when the call to ga comes back, or after a timeout define by gaTimeout
  * it will never be rejected
@@ -162,4 +161,17 @@ export function trackPayment(price, currency) {
     });
 
     return event('Payment', 'Contribute', 'purchase');
+}
+
+export function waitForGA() {
+    return new Promise(resolve => {
+        function wait() {
+            if (window.ga === undefined) {
+                setTimeout(wait, 100);
+            } else {
+                return resolve();
+            }
+        }
+        wait();
+    })
 }


### PR DESCRIPTION
@guardian/contributions 

This pull request fixes a bug which prevents events being fired for the `AARecurringTest`. The bug was due to trying to fire a GA event before GA had initialised.

As suggested, to fix this I have created a function which returns a promise which resolves only when GA has been initialised (i.e. `window.ga` is not `undefined`).

I have deployed the branch to `CODE` and [event tracking tracker](https://chrome.google.com/webstore/detail/event-tracking-tracker/npjkfahkbgoagkfpkidpjdemjjmmbcim) reports that the event is now fired.
