### PR TITLE
logger.conf updated

### DIFF
--- a/conf/logger.conf
+++ b/conf/logger.conf
@@ -1,8 +1,9 @@
 [general]
 state_file = /var/awslogs/agent-state
 
-[/membership/logs/frontend.log]
-file = /membership/logs/giraffe.log
-log_group_name = FrontendLogs-__STAGE
-log_stream_name = __DATE/__BUILD/{instance_id}/giraffe.log
-datetime_format = %Y-%m-%d %H:%M-%S
+[contributions-logstream]
+file = /var/log/contributions-frontend/application.log
+log_group_name = contributions-frontend-__STAGE
+log_stream_name = __DATE/__BUILD/{instance_id}/application.log
+datetime_format = %Y/%m/%d %H:%M:%S,%f
+


### PR DESCRIPTION
@guardian/contributions 

The aim of this pull request is to ensure that the contribution-frontend logs are:

1. successfully sent to CloudWatch
2. stored within their own log group in CloudWatch