### PR TITLE
fetch the country code for paypal payments

### DIFF
--- a/app/models/PaymentHook.scala
+++ b/app/models/PaymentHook.scala
@@ -63,13 +63,13 @@ case class PaymentHook(
 )
 
 object PaymentHook {
-  def fromPaypal(paypalHook: PaypalHook): PaymentHook = PaymentHook(
+  def fromPaypal(paypalHook: PaypalHook, countryCode: Option[String]): PaymentHook = PaymentHook(
     contributionId = paypalHook.contributionId,
     paymentId = paypalHook.paymentId,
     provider = Paypal,
     created = paypalHook.created,
     currency = paypalHook.currency,
-    cardCountry = None,
+    cardCountry = countryCode,
     amount = paypalHook.amount,
     convertedAmount = None,
     status = paypalHook.status,

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -250,8 +250,21 @@ class PaypalService(
     Event.validateReceivedEvent(context, headers.asJava, body)
   }
 
-  def processPaymentHook(paypalHook: PaypalHook): XorT[Future, String, PaymentHook] =
-    contributionData.insertPaymentHook(PaymentHook.fromPaypal(paypalHook))
+  def processPaymentHook(paypalHook: PaypalHook): XorT[Future, String, PaymentHook] = {
+
+    def countryCode(rawPayment: Payment): Option[String] = for {
+      payment <- Option(rawPayment)
+      payer <- Option(payment.getPayer)
+      info <- Option(payer.getPayerInfo)
+      countryCode <- Option(info.getCountryCode)
+    } yield countryCode
+
+    for {
+      payment <- asyncExecute(Payment.get(apiContext, paypalHook.paymentId))
+      result <- contributionData.insertPaymentHook(PaymentHook.fromPaypal(paypalHook, countryCode(payment)))
+    } yield result
+  }
+
 
 
 }

--- a/test/models/PaymentHookSpec.scala
+++ b/test/models/PaymentHookSpec.scala
@@ -28,7 +28,7 @@ class PaymentHookSpec extends WordSpec with MustMatchers {
     "be able to parse paypal's json and convert it to a payment hook" in {
 
       val json = Json.parse(paypalJson)
-      val jsResult = PaypalHook.reader.reads(json).map(PaymentHook.fromPaypal)
+      val jsResult = PaypalHook.reader.reads(json).map(hook => PaymentHook.fromPaypal(hook, Some("US")))
 
       jsResult mustBe a [JsSuccess[_]]
       jsResult.get mustEqual PaymentHook(
@@ -37,7 +37,7 @@ class PaymentHookSpec extends WordSpec with MustMatchers {
         provider = Paypal,
         created = new DateTime("2016-08-10T09:49:14Z"),
         currency = "GBP",
-        cardCountry = None,
+        cardCountry = Some("US"),
         amount = BigDecimal("22.00"),
         convertedAmount = None,
         status = Paid,


### PR DESCRIPTION
When the webhook comes back, query the paypal API to fetch the country code.
Both paypal and stripe use the 2 characters ISO 3166-1 country code, so I'm putting them in the same column.
The column is named cardCountry and does not exactly represent what it now contains, I'm not sure if it is worth renaming (opinion appreciated on the matter)

@guardian/contributions 