### PR TITLE
additional changes as logs still aren't being sent to cloud watch

### DIFF
--- a/cloud-formation/cfn.yml
+++ b/cloud-formation/cfn.yml
@@ -144,7 +144,6 @@
                     -
                       - "sed -i"
                       - " -e \"s/__DATE/$(date +%F)/\""
-                      - " -e \"s/__BUILD/$(cat $CONF_DIR/build.txt)/\""
                       - " -e 's/__STAGE/"
                       -
                         Ref: "Stage"
@@ -158,6 +157,8 @@
                       -
                         Ref: "AWS::Region"
                       - "-c $CONF_DIR/logger.conf"
+                - "systemctl enable awslogs"
+                - "systemctl start awslogs"
 
     ContributionsAppRole:
       Type: "AWS::IAM::Role"

--- a/conf/logger.conf
+++ b/conf/logger.conf
@@ -3,7 +3,6 @@ state_file = /var/awslogs/agent-state
 
 [contributions-logstream]
 file = /var/log/contributions-frontend/application.log
-log_group_name = contributions-frontend-__STAGE
-log_stream_name = __DATE/__BUILD/{instance_id}/application.log
+log_group_name = ContributionsFrontend-__STAGE
+log_stream_name = __DATE/{instance_id}/application.log
 datetime_format = %Y/%m/%d %H:%M:%S,%f
-


### PR DESCRIPTION
@guardian/contributions 

Logs were still not being sent. I believe it was due to the issue raised [here](https://forums.aws.amazon.com/thread.jspa?threadID=233351&tstart=0#748904).

I have deployed the latest version of this branch to `CODE` and can confirm the logs are now being sent to Cloud Watch.

I've also changed the name of our log group to make it more consistent with the other log groups in Cloud Watch.

@philwills do you want to merge your changes first?