### PR TITLE
Allow us to use any EC2 instance type

### DIFF
--- a/cloud-formation/cfn.yml
+++ b/cloud-formation/cfn.yml
@@ -31,11 +31,6 @@
     InstanceType:
       Description: "EC2 instance type"
       Type: "String"
-      AllowedValues:
-        - "t2.micro"
-        - "t2.medium"
-        - "m3.medium"
-      ConstraintDescription: "must be a valid EC2 instance type."
     ImageId:
       Description: "AMI ID"
       Type: "String"


### PR DESCRIPTION
I'd rather not have to update CFN if for some reason we want to use beefier instances.