### PR TITLE
Add referer URL and referer pageview id processing

### DIFF
--- a/app/controllers/Giraffe.scala
+++ b/app/controllers/Giraffe.scala
@@ -59,6 +59,8 @@ class Giraffe(paymentServices: PaymentServices, addToken: CSRFAddToken) extends 
       val stripe = paymentServices.stripeServiceFor(request)
       val cmp = request.getQueryString("CMP")
       val intCmp = request.getQueryString("INTCMP")
+      val refererPageviewId = request.getQueryString("REFPVID")
+      val refererUrl = request.headers.get("referer")
 
       val pageInfo = PageInfo(
         title = "Support the Guardian | Contribute today",
@@ -75,7 +77,7 @@ class Giraffe(paymentServices: PaymentServices, addToken: CSRFAddToken) extends 
       val testsInCookies = request.cookies.filter(_.name.contains(Test.CookiePrefix)) map (_.name)
 
       Ok(views.html.giraffe.contribute(pageInfo, maxAmountInLocalCurrency, countryGroup, variant, cmp, intCmp,
-        creditCardExpiryYears, errorMessage, CSRF.getToken.map(_.value)))
+        refererPageviewId, refererUrl, creditCardExpiryYears, errorMessage, CSRF.getToken.map(_.value)))
         .discardingCookies(testsInCookies.toSeq map (DiscardingCookie(_)): _*)
         .withCookies(Test.testIdCookie(mvtId), Test.variantCookie(variant))
     }

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -39,6 +39,8 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
     payerId: String,
     cmp: Option[String],
     intCmp: Option[String],
+    refererPageviewId: Option[String],
+    refererUrl: Option[String],
     ophanPageviewId: Option[String],
     ophanBrowserId: Option[String]
   ) = NoCacheAction.async { implicit request =>
@@ -50,7 +52,7 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
       val variant = Test.getContributePageVariant(countryGroup, mvtId, request)
       val idUser = IdentityId.fromRequest(request)
 
-      paypalService.storeMetaData(paymentId, Seq(variant), cmp, intCmp, ophanPageviewId, ophanBrowserId, idUser)
+      paypalService.storeMetaData(paymentId, Seq(variant), cmp, intCmp, refererPageviewId, refererUrl, ophanPageviewId, ophanBrowserId, idUser)
         .leftMap[AppError](StoreMetaDataError) // not necessary if storeMetaData() returns a custom error type
         .map(data => (payment, data))
     }
@@ -81,6 +83,8 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
     amount: BigDecimal,
     cmp: Option[String],
     intCmp: Option[String],
+    refererPageviewId: Option[String],
+    refererUrl: Option[String],
     ophanPageviewId: Option[String],
     ophanBrowserId: Option[String]
   )
@@ -91,6 +95,8 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
         (__ \ "amount").read(min[BigDecimal](1)) and
         (__ \ "cmp").readNullable[String] and
         (__ \ "intCmp").readNullable[String] and
+        (__ \ "refererPageviewId").readNullable[String] and
+        (__ \ "refererUrl").readNullable[String] and
         (__ \ "ophanPageviewId").readNullable[String] and
         (__ \ "ophanBrowserId").readNullable[String]
       ) (AuthRequest.apply _)
@@ -125,6 +131,8 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
             contributionId = ContributionId.random,
             cmp = authRequest.cmp,
             intCmp = authRequest.intCmp,
+            refererPageviewId = authRequest.refererPageviewId,
+            refererUrl = authRequest.refererUrl,
             ophanPageviewId = authRequest.ophanPageviewId,
             ophanBrowserId = authRequest.ophanBrowserId
           )

--- a/app/controllers/Redirect.scala
+++ b/app/controllers/Redirect.scala
@@ -5,7 +5,7 @@ import play.api.mvc.{Controller, Request}
 trait Redirect {
   self: Controller =>
   def redirectWithCampaignCodes(destinationUrl: String, additionalParams: Set[String] = Set.empty)(implicit request: Request[Any]) = {
-    val queryParamsToForward = Set("INTCMP", "CMP") ++ additionalParams
+    val queryParamsToForward = Set("INTCMP", "CMP", "REFPVID") ++ additionalParams
     Redirect(destinationUrl, request.queryString.filterKeys(queryParamsToForward), SEE_OTHER)
   }
 }

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -60,7 +60,9 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
     ophanPageviewId: String,
     ophanBrowserId: Option[String],
     cmp: Option[String],
-    intcmp: Option[String]
+    intcmp: Option[String],
+    refererPageviewId: Option[String],
+    refererUrl: Option[String]
 
   )
 
@@ -82,7 +84,9 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
       "ophanPageviewId" -> text,
       "ophanBrowserId" -> optional(text),
       "cmp" -> optional(text),
-      "intcmp" -> optional(text)
+      "intcmp" -> optional(text),
+      "refererPageviewId" -> optional(text),
+      "refererUrl" -> optional(text)
     )(SupportForm.apply)(SupportForm.unapply)
   )
 
@@ -113,6 +117,8 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
       "ophanBrowserId" -> form.ophanBrowserId.getOrElse(""),
       "cmp" -> form.cmp.mkString,
       "intcmp" -> form.intcmp.mkString,
+      "refererPageviewId" -> form.refererPageviewId.mkString,
+      "refererUrl" -> form.refererUrl.mkString,
       "contributionId" -> contributionId.toString
     ) ++ List(
       form.postcode.map("postcode" -> _),
@@ -140,6 +146,8 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
         variants = Seq(variant),
         cmp = form.cmp,
         intCmp = form.intcmp,
+        refererPageviewId = form.refererPageviewId,
+        refererUrl = form.refererUrl,
         ophanPageviewId = form.ophanPageviewId,
         ophanBrowserId = form.ophanBrowserId,
         idUser = idUser

--- a/app/data/ContributionData.scala
+++ b/app/data/ContributionData.scala
@@ -74,7 +74,9 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) {
           ophan_browser_id,
           abtests,
           cmp,
-          intcmp
+          intcmp,
+          referer_url,
+          referer_pageview_id
         ) VALUES (
           ${pmd.contributionId.id}::uuid,
           ${pmd.created},
@@ -84,7 +86,9 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) {
           ${pmd.ophanBrowserId},
           ${pmd.abTests},
           ${pmd.cmp},
-          ${pmd.intCmp}
+          ${pmd.intCmp},
+          ${pmd.refererUrl},
+          ${pmd.refererPageviewId}
         ) ON CONFLICT(contributionId) DO
         UPDATE SET
           contributionid = excluded.contributionid,
@@ -95,7 +99,9 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) {
           ophan_browser_id = excluded.ophan_browser_id,
           abtests = excluded.abtests,
           cmp = excluded.cmp,
-          intcmp = excluded.intcmp"""
+          intcmp = excluded.intcmp,
+          referer_url = excluded.referer_url,
+          referer_pageview_id = excluded.referer_pageview_id"""
       request.execute()
       pmd
     }

--- a/app/models/ContributionMetaData.scala
+++ b/app/models/ContributionMetaData.scala
@@ -12,5 +12,7 @@ case class ContributionMetaData(
   ophanBrowserId: Option[String],
   abTests: JsValue,
   cmp: Option[String],
-  intCmp: Option[String]
+  intCmp: Option[String],
+  refererPageviewId: Option[String],
+  refererUrl: Option[String]
 )

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -77,6 +77,8 @@ class PaypalService(
     contributionId: ContributionId,
     cmp: Option[String],
     intCmp: Option[String],
+    refererPageviewId: Option[String],
+    refererUrl: Option[String],
     ophanPageviewId: Option[String],
     ophanBrowserId: Option[String]
   ): EitherT[Future, String, Uri] = {
@@ -88,7 +90,9 @@ class PaypalService(
           cmp.map(value => s"CMP=$value"),
           intCmp.map(value => s"INTCMP=$value"),
           ophanPageviewId.map(value => s"pvid=$value"),
-          ophanBrowserId.map(value => s"bid=$value")
+          ophanBrowserId.map(value => s"bid=$value"),
+          refererPageviewId.map(value => s"refererPageviewId=$value"),
+          refererUrl.map(value => s"refererUrl=$value")
         ).flatten match {
           case Nil => ""
           case params => params.mkString("?", "&", "")
@@ -150,6 +154,8 @@ class PaypalService(
     variants: Seq[Variant],
     cmp: Option[String],
     intCmp: Option[String],
+    refererPageviewId: Option[String],
+    refererUrl: Option[String],
     ophanPageviewId: Option[String],
     ophanBrowserId: Option[String],
     idUser: Option[IdentityId]
@@ -178,7 +184,9 @@ class PaypalService(
         ophanBrowserId = ophanBrowserId,
         abTests = Json.toJson(variants),
         cmp = cmp,
-        intCmp = intCmp
+        intCmp = intCmp,
+        refererPageviewId =refererPageviewId,
+        refererUrl = refererUrl
       )
 
       val postCode = {

--- a/app/services/StripeService.scala
+++ b/app/services/StripeService.scala
@@ -33,6 +33,8 @@ class StripeService(
     variants: Seq[Variant],
     cmp: Option[String],
     intCmp: Option[String],
+    refererPageviewId: Option[String],
+    refererUrl: Option[String],
     ophanPageviewId: String,
     ophanBrowserId: Option[String],
     idUser: Option[IdentityId]
@@ -60,7 +62,9 @@ class StripeService(
       ophanBrowserId = ophanBrowserId,
       abTests = Json.toJson(variants),
       cmp = cmp,
-      intCmp = intCmp
+      intCmp = intCmp,
+      refererPageviewId = refererPageviewId,
+      refererUrl = refererUrl
     )
     val contributor = Contributor(
       email = charge.receipt_email,

--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -12,6 +12,8 @@
     variant: Variant,
     cmpCode: Option[String],
     intCmpCode: Option[String],
+    refererPageviewId: Option[String],
+    refererUrl: Option[String],
     creditCardExpiryYears: List[Int],
     errorMessage: Option[String],
     csrfToken: Option[String]
@@ -31,6 +33,13 @@
         @for(code <- intCmpCode) {
             data-int-cmp-code="@code"
         }
+        @for(refId <- refererPageviewId) {
+            data-referrer-pageview-id="@refId"
+        }
+        @for(refUrl <- refererUrl) {
+            data-referrer-url="@refUrl"
+        }
+
     >
     </section>
 

--- a/assets/javascripts/src/actions.es6
+++ b/assets/javascripts/src/actions.es6
@@ -66,6 +66,8 @@ export function paypalRedirect(dispatch) {
         amount: state.card.amount, //TODO should the amount be somewhere else rather than in the card section?,
         cmp: state.data.cmpCode,
         intCmp: state.data.intCmpCode,
+        refererPageviewId: state.data.refererPageviewId,
+        refererUrl: state.data.refererUrl,
         ophanPageviewId: state.data.ophan.pageviewId,
         ophanBrowserId: state.data.ophan.browserId
     };
@@ -126,6 +128,8 @@ function paymentFormData(state, token) {
         ophanPageviewId: state.data.ophan.pageviewId,
         ophanBrowserId: state.data.ophan.browserId,
         cmp: state.data.cmpCode,
-        intcmp: state.data.intCmpCode
+        intcmp: state.data.intCmpCode,
+        refererPageviewId: state.data.refererPageviewId,
+        refererUrl: state.data.refererUrl
     };
 }

--- a/assets/javascripts/src/modules/contribute.es6
+++ b/assets/javascripts/src/modules/contribute.es6
@@ -69,6 +69,8 @@ function appDataFrom(container) {
         currency: currency,
         cmpCode: container.getAttribute('data-cmp-code'),
         intCmpCode: container.getAttribute('data-int-cmp-code'),
+        refererPageviewId: container.getAttribute('data-referrer-pageview-id'),
+        refererUrl: container.getAttribute('data-referrer-url'),
         csrfToken: container.getAttribute('data-csrf-token')
     };
 }

--- a/assets/javascripts/src/reducers/data.es6
+++ b/assets/javascripts/src/reducers/data.es6
@@ -14,6 +14,8 @@ const initialState = {
     },
     cmpCode: '',
     intCmpCode: '',
+    refererPageviewId: '',
+    refererUrl: '',
     ophan: {
         pageviewId: null,
         browserId: null

--- a/conf/routes
+++ b/conf/routes
@@ -16,7 +16,7 @@ GET            /home                            controllers.Giraffe.contributeRe
 GET            /healthcheck                     controllers.Healthcheck.healthcheck
 POST           /paypal/auth                     controllers.PaypalController.authorize
 
-GET            /paypal/:countryGroup/execute    controllers.PaypalController.executePayment(countryGroup: CountryGroup, paymentId, token, PayerID, CMP: Option[String], INTCMP: Option[String], pvid: Option[String], bid: Option[String])
+GET            /paypal/:countryGroup/execute    controllers.PaypalController.executePayment(countryGroup: CountryGroup, paymentId, token, PayerID, CMP: Option[String], INTCMP: Option[String], refererPageviewId: Option[String], refererUrl: Option[String],pvid: Option[String], bid: Option[String])
 POST           /paypal/hook                     controllers.PaypalController.hook
 POST           /:countryGroup/update-metadata   controllers.PaypalController.updateMetadata(countryGroup:CountryGroup)
 


### PR DESCRIPTION
We now want to store the referer URL and pageview ID (if either exist) in PostGres so that we can better analyse what content is driving Contributions. 

The referer URL is taken from the request header and the pageview ID is passed in as a query string parameter. 

@alexduf 