### PR TITLE
Fix credit card number input on webview

### DIFF
--- a/assets/javascripts/src/components/pages/Payment.jsx
+++ b/assets/javascripts/src/components/pages/Payment.jsx
@@ -46,7 +46,7 @@ export default class Payment extends React.Component {
     render() {
         return <div className='contribute-payment contribute-fields'>
 
-            <InputField label="Card number" type="text" value={formatCardNumber(this.props.card.number)}
+            <InputField label="Card number" type="tel" value={formatCardNumber(this.props.card.number)}
                         autoFocus={window.matchMedia('(min-width: 741px)').matches}
                         onChange={event => this.props.updateCard({number: event.target.value})}
                         onKeyDown={event => this.clearValidation(event.target)}
@@ -60,7 +60,7 @@ export default class Payment extends React.Component {
 
             <div className="flex-horizontal">
                 <InputField label="Expiry date"
-                            type="text"
+                            type="tel"
                             value={this.props.card.expiry}
                             onChange={event => this.props.updateCard({expiry: this.formatExpiry(event.target.value)})}
                             onKeyDown={event => this.clearValidation(event.target)}
@@ -72,7 +72,7 @@ export default class Payment extends React.Component {
                             required/>
 
                 <InputField label="Security code"
-                            type="text"
+                            type="number"
                             value={this.props.card.cvc}
                             onChange={event => this.props.updateCard({cvc: event.target.value})}
                             onKeyDown={event => this.clearValidation(event.target)}


### PR DESCRIPTION
The formatting of the credit card was interfering with the behaviour of the android webview and was causing the caret to be in the wrong position, messing with the user input.
Using the input type "tel" seems to work around the issue and provides a numeric keyboard on mobile devices.
Tested with browser stack on firefox for windows, safari, safari mobile, tested on chrome, firefox, firefox mobile and the webview within the app.

cc @guardian/contributions 