### PR TITLE
Keep platform parameter

### DIFF
--- a/app/controllers/Redirect.scala
+++ b/app/controllers/Redirect.scala
@@ -12,6 +12,6 @@ trait Redirect {
   }
 
   def thankYouMobileUri(amount: ContributionAmount): String = {
-    s"x-gu://contribution?date${LocalDate.now().toString}&amount=$amount"
+    s"x-gu://contribution?date=${LocalDate.now().toString}&amount=$amount"
   }
 }

--- a/app/controllers/Redirect.scala
+++ b/app/controllers/Redirect.scala
@@ -7,7 +7,7 @@ import play.api.mvc.{Controller, Request}
 trait Redirect {
   self: Controller =>
   def redirectWithCampaignCodes(destinationUrl: String, additionalParams: Set[String] = Set.empty)(implicit request: Request[Any]) = {
-    val queryParamsToForward = Set("INTCMP", "CMP", "REFPVID") ++ additionalParams
+    val queryParamsToForward = Set("INTCMP", "CMP", "REFPVID", "platform") ++ additionalParams
     Redirect(destinationUrl, request.queryString.filterKeys(queryParamsToForward), SEE_OTHER)
   }
 


### PR DESCRIPTION
To facilitate tracking in ophan, we should keep the platform parameter in the URL

This PR also fixes a typo in the deep-link post-payment

cc @guardian/contributions 