### PR TITLE
App flow optimisation

### DIFF
--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -48,7 +48,9 @@ object CommonActions {
 
   implicit class MobileSupportRequest[A](val request: Request[A]) extends AnyVal {
     def platform: Option[String] = request.getQueryString("platform") orElse request.session.get("platform")
-    def isMobile: Boolean = platform.contains("android") || platform.contains("ios")
+    def isAndroid: Boolean = platform.contains("android")
+    def isIos: Boolean = platform.contains("ios")
+    def isMobile: Boolean = isAndroid || isIos
   }
 
   object MobileSupportAction extends ActionBuilder[Request] {

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -7,6 +7,7 @@ import com.gu.i18n.CountryGroup._
 import com.gu.i18n._
 import com.netaporter.uri.dsl._
 import configuration.Config
+import models.ContributionAmount
 import play.api.mvc._
 import play.filters.csrf.{CSRF, CSRFAddToken}
 import services.PaymentServices
@@ -89,12 +90,17 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken) ex
     val charge = request.session.get("charge_id")
     val title = "Thank you!"
 
+    val iosRedirectUrl = request.session.get("amount")
+      .flatMap(ContributionAmount.apply)
+      .map(mobileRedirectUrl)
+      .filter(_ => request.isIos)
+
     Ok(views.html.giraffe.thankyou(PageInfo(
       title = title,
       url = request.path,
       image = None,
       description = Some("You’ve made a vital contribution that will help us maintain our independent, investigative journalism")
-    ), social, countryGroup, charge))
+    ), social, countryGroup, charge, iosRedirectUrl))
   }
 }
 

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -3,6 +3,7 @@ package controllers
 import actions.CommonActions._
 import cats.data.EitherT
 import cats.instances.future._
+import cats.syntax.show._
 import cookies.ContribTimestampCookieAttributes
 import cookies.syntax._
 import com.gu.i18n.{CountryGroup, Currency}
@@ -71,7 +72,7 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
 
       val session = List(
         "email" -> savedData.contributor.email
-      ) ++ amount.map("amount" -> _.toString)
+      ) ++ amount.map("amount" -> _.show)
 
       redirectWithCampaignCodes(redirectUrl)
         .addingToSession(session :_ *)

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -8,8 +8,7 @@ import cookies.syntax._
 import com.gu.i18n.{CountryGroup, Currency}
 import com.netaporter.uri.Uri
 import com.paypal.api.payments.Payment
-import models.SavedContributionData
-import models.{ContributionId, IdentityId, PaypalHook}
+import models._
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.PaymentServices
@@ -66,14 +65,13 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
     def okResult(data: (Payment, SavedContributionData)): Result = {
       val (payment, savedData) = data
 
-      val mobileUrl = paypalService.paymentAmount(payment)
-        .filter(_ => request.isMobile)
-        .map(thankYouMobileUri)
+      val redirectUrl = routes.Contributions.postPayment(countryGroup).url
 
-      val redirectUrl = mobileUrl.getOrElse(routes.Contributions.postPayment(countryGroup).url)
+      val amount = paypalService.paymentAmount(payment)
 
       redirectWithCampaignCodes(redirectUrl)
-        .withSession(request.session + ("email" -> savedData.contributor.email))
+        .addingToSession("email" -> savedData.contributor.email)
+        .addingToSession("amount" -> amount.toString)
         .setCookie[ContribTimestampCookieAttributes](payment.getCreateTime)
     }
 
@@ -190,17 +188,22 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
     )(MetadataUpdate.apply)(MetadataUpdate.unapply)
   )
 
-  def updateMetadata(countryGroup: CountryGroup) = NoCacheAction.async(parse.form(metadataUpdateForm)) {
-    implicit request =>
-      val paypalService = paymentServices.paypalServiceFor(request)
-      val marketingOptIn = request.body.marketingOptIn
-      val idUser = IdentityId.fromRequest(request)
-      val contributor = request.session.data.get("email") match {
-        case Some(email) => paypalService.updateMarketingOptIn(email, marketingOptIn, idUser).value
-        case None => Future.successful(Logger.error("email not found in session while trying to update marketing opt in"))
-      }
-      contributor.map { _ =>
-        Redirect(routes.Contributions.thanks(countryGroup).url, SEE_OTHER)
-      }
+  def updateMetadata(countryGroup: CountryGroup) = NoCacheAction.async(parse.form(metadataUpdateForm)) { implicit request =>
+    val paypalService = paymentServices.paypalServiceFor(request)
+    val marketingOptIn = request.body.marketingOptIn
+    val idUser = IdentityId.fromRequest(request)
+    val contributor = request.session.data.get("email") match {
+      case Some(email) => paypalService.updateMarketingOptIn(email, marketingOptIn, idUser).value
+      case None => Future.successful(Logger.error("email not found in session while trying to update marketing opt in"))
+    }
+
+    val url = request.session.get("amount").flatMap(ContributionAmount.apply)
+      .filter(_ => request.isAndroid)
+      .map(thankYouMobileUri)
+      .getOrElse(routes.Contributions.thanks(countryGroup).url)
+
+    contributor.map { _ =>
+      Redirect(url, SEE_OTHER)
+    }
   }
 }

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -69,9 +69,12 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
 
       val amount = paypalService.paymentAmount(payment)
 
+      val session = List(
+        "email" -> savedData.contributor.email
+      ) ++ amount.map("amount" -> _.toString)
+
       redirectWithCampaignCodes(redirectUrl)
-        .addingToSession("email" -> savedData.contributor.email)
-        .addingToSession("amount" -> amount.toString)
+        .addingToSession(session :_ *)
         .setCookie[ContribTimestampCookieAttributes](payment.getCreateTime)
     }
 
@@ -199,7 +202,7 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
 
     val url = request.session.get("amount").flatMap(ContributionAmount.apply)
       .filter(_ => request.isAndroid)
-      .map(thankYouMobileUri)
+      .map(mobileRedirectUrl)
       .getOrElse(routes.Contributions.thanks(countryGroup).url)
 
     contributor.map { _ =>

--- a/app/controllers/Redirect.scala
+++ b/app/controllers/Redirect.scala
@@ -11,7 +11,7 @@ trait Redirect {
     Redirect(destinationUrl, request.queryString.filterKeys(queryParamsToForward), SEE_OTHER)
   }
 
-  def thankYouMobileUri(amount: ContributionAmount): String = {
+  def mobileRedirectUrl(amount: ContributionAmount): String = {
     s"x-gu://contribution?date=${LocalDate.now().toString}&amount=$amount"
   }
 }

--- a/app/controllers/Redirect.scala
+++ b/app/controllers/Redirect.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import cats.syntax.show._
 import models.ContributionAmount
 import org.joda.time.LocalDate
 import play.api.mvc.{Controller, Request}
@@ -12,6 +13,6 @@ trait Redirect {
   }
 
   def mobileRedirectUrl(amount: ContributionAmount): String = {
-    s"x-gu://contribution?date=${LocalDate.now().toString}&amount=$amount"
+    s"x-gu://contribution?date=${LocalDate.now().toString}&amount=${amount.show}"
   }
 }

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -5,6 +5,7 @@ import java.time.Instant
 
 import actions.CommonActions._
 import cats.data.EitherT
+import cats.syntax.show._
 import cookies.ContribTimestampCookieAttributes
 import cookies.syntax._
 import com.gu.i18n.CountryGroup._
@@ -160,7 +161,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
       storeMetaData(charge) // fire and forget. If it fails we don't want to stop the user
       Ok(Json.obj("redirect" -> thankYouUri))
         .addingToSession("charge_id" -> charge.id)
-        .addingToSession("amount" -> contributionAmount.toString)
+        .addingToSession("amount" -> contributionAmount.show)
         .setCookie[ContribTimestampCookieAttributes](Instant.ofEpochSecond(charge.created).toString)
     }.recover {
       case e: Stripe.Error => BadRequest(Json.toJson(e))

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -125,9 +125,10 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
     val amountInSmallestCurrencyUnit = (form.amount * 100).toInt
     val maxAmountInSmallestCurrencyUnit = MaxAmount.forCurrency(form.currency) * 100
     val amount = min(maxAmountInSmallestCurrencyUnit, amountInSmallestCurrencyUnit)
+    val contributionAmount = ContributionAmount(BigDecimal(amount, 2), form.currency)
 
-    def thankYouUri = if (request.isMobile) {
-      thankYouMobileUri(ContributionAmount(BigDecimal(amount, 2), form.currency))
+    def thankYouUri = if (request.isAndroid) {
+      mobileRedirectUrl(contributionAmount)
     } else {
       routes.Contributions.thanks(countryGroup).url
     }
@@ -158,7 +159,8 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
     createCharge.map { charge =>
       storeMetaData(charge) // fire and forget. If it fails we don't want to stop the user
       Ok(Json.obj("redirect" -> thankYouUri))
-        .withSession("charge_id" -> charge.id)
+        .addingToSession("charge_id" -> charge.id)
+        .addingToSession("amount" -> contributionAmount.toString)
         .setCookie[ContribTimestampCookieAttributes](Instant.ofEpochSecond(charge.created).toString)
     }.recover {
       case e: Stripe.Error => BadRequest(Json.toJson(e))

--- a/app/models/ContributionAmount.scala
+++ b/app/models/ContributionAmount.scala
@@ -1,5 +1,6 @@
 package models
 
+import cats.Show
 import com.gu.i18n.Currency
 
 import scala.util.Try
@@ -7,9 +8,7 @@ import scala.util.Try
 case class ContributionAmount(
   amount: BigDecimal,
   currency: Currency
-) {
-  override def toString: String = f"$amount%1.2f$currency"
-}
+)
 
 object ContributionAmount {
   def apply(amount: String): Option[ContributionAmount] = {
@@ -20,4 +19,6 @@ object ContributionAmount {
       currency <- Currency.fromString(currencyString)
     } yield ContributionAmount(number, currency)
   }
+
+  implicit val showContributionAmount: Show[ContributionAmount] = Show.show(f => f"${f.amount}%1.2f${f.currency}")
 }

--- a/app/models/ContributionAmount.scala
+++ b/app/models/ContributionAmount.scala
@@ -2,9 +2,22 @@ package models
 
 import com.gu.i18n.Currency
 
+import scala.util.Try
+
 case class ContributionAmount(
   amount: BigDecimal,
   currency: Currency
 ) {
   override def toString: String = f"$amount%1.2f$currency"
+}
+
+object ContributionAmount {
+  def apply(amount: String): Option[ContributionAmount] = {
+    val numberString = amount.dropRight(3)
+    val currencyString = amount.drop(numberString.length)
+    for {
+      number <- Try(BigDecimal.apply(numberString)).toOption
+      currency <- Currency.fromString(currencyString)
+    } yield ContributionAmount(number, currency)
+  }
 }

--- a/app/views/giraffe/thankyou.scala.html
+++ b/app/views/giraffe/thankyou.scala.html
@@ -2,27 +2,32 @@
 
 @import views.support.Social
 @import com.gu.i18n.CountryGroup
-@(pageInfo: PageInfo, social: Set[Social], countryGroup: CountryGroup, charge: Option[String])
+@(pageInfo: PageInfo, social: Set[Social], countryGroup: CountryGroup, charge: Option[String], iosRedirectUrl: Option[String])
     @main(pageInfo, mainScript = Some("thankYouPage.js")) {
     <script type="text/javascript">
         @if(charge.isDefined) {
-          guardian.productDetails = {
-            charge: '@charge.get'
-        };
+            guardian.productDetails = {
+                charge: '@charge.get'
+            };
         }
-
-
     </script>
     <main class="contributions__wrapper currency-@countryGroup.currency.toString.toLowerCase">
         <div class="contributions__inner page-slice l-constrained flex-horizontal-from-tablet thanks">
             <section>
             <h1>@pageInfo.title
-
-            <span class="thanks--description">@pageInfo.description</span>
-                </h1>
+                <span class="thanks--description">@pageInfo.description</span>
+            </h1>
+            @if(iosRedirectUrl.isDefined) {
+                <a class="action action--button action--button--forward action action--button contribute-navigation__next action--next" href="@iosRedirectUrl.get">
+                    <span>Return to the Guardian app</span>
+                    <svg class="action--button__arrow" xmlns="http://www.w3.org/2000/svg" width="20" height="17.89" viewBox="0 0 20 17.89">
+                        <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84zm20-.81L49.08 0l.86.81-6.54 7.31H60v1.65H43.4l6.54 7.31-.86.81L40 9.39v-.85z"/>
+                    </svg>
+                </a>
+            }
             </section>
- </div>
-</main>
+        </div>
+    </main>
     <section class="disclaimer">
         <div class="support-wrapper page-slice page-slice__feedback l-constrained currency-@countryGroup.currency.toString.toLowerCase">
             <div class="feedback">


### PR DESCRIPTION
This will change:

 - android app users paying with paypal: will see the email page before being redirected
 - ios app users paying with paypal or stripe: will be redirected to the thank you page, onto which a button will be there

The idea behind that change in the worflow is to warn the ios app user about being redirected as otherwise they will see that odd popup asking them if they want to open the guardian app.

cc @guardian/contributions 

![iphone5](https://cloud.githubusercontent.com/assets/3389563/23263989/c40322ca-f9d7-11e6-9a54-9f3e5602cbec.png)
