### PR TITLE
Remove header in Android app

### DIFF
--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -57,6 +57,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken) ex
       val intCmp = request.getQueryString("INTCMP")
       val refererPageviewId = request.getQueryString("REFPVID")
       val refererUrl = request.headers.get("referer")
+      val platform = request.getQueryString("platform")
 
       val pageInfo = PageInfo(
         title = "Support the Guardian | Contribute today",
@@ -81,7 +82,8 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken) ex
         refererUrl,
         creditCardExpiryYears,
         errorMessage,
-        CSRF.getToken.map(_.value)
+        CSRF.getToken.map(_.value),
+        platform
       ))
     }
   }

--- a/app/views/fragments/giraffe/contributionsMain.scala.html
+++ b/app/views/fragments/giraffe/contributionsMain.scala.html
@@ -7,9 +7,11 @@
     countryGroup: CountryGroup,
     maxAmount: Option[Int] = None,
     mainScript: Option[String] = None,
-    errorMessage:Option[String])(content: Html)
+    errorMessage: Option[String],
+    platform: Option[String]
+)(content: Html)
 
-@main(pageInfo, Some(countryGroup), maxAmount, mainScript) {
+@main(pageInfo, Some(countryGroup), maxAmount, mainScript, platform) {
     <main class="contributions__wrapper currency-@countryGroup.currency.toString.toLowerCase">
 
         @for(message <- errorMessage) {

--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -16,10 +16,11 @@
     refererUrl: Option[String],
     creditCardExpiryYears: List[Int],
     errorMessage: Option[String],
-    csrfToken: Option[String]
+    csrfToken: Option[String],
+    platform: Option[String]
 )
 
-@contributionsMain(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage) {
+@contributionsMain(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage, platform) {
 
     <!-- react injects its components here -->
     <section id="contribute" class="contribute-container"

--- a/app/views/giraffe/postPayment.scala.html
+++ b/app/views/giraffe/postPayment.scala.html
@@ -1,9 +1,9 @@
 @import com.gu.i18n.CountryGroup
 @import views.support.PageInfo
 @import fragments.giraffe.contributionsMain
-@(pageInfo: PageInfo, countryGroup: CountryGroup)
+@(pageInfo: PageInfo, countryGroup: CountryGroup, platform: Option[String])
 
-@contributionsMain(pageInfo, countryGroup, None, None, None) {
+@contributionsMain(pageInfo, countryGroup, None, None, None, platform) {
 
     <div class="contribute-container">
         <div class="contribute-section postPaymentConfirmation">

--- a/app/views/giraffe/thankyou.scala.html
+++ b/app/views/giraffe/thankyou.scala.html
@@ -2,8 +2,8 @@
 
 @import views.support.Social
 @import com.gu.i18n.CountryGroup
-@(pageInfo: PageInfo, social: Set[Social], countryGroup: CountryGroup, charge: Option[String], iosRedirectUrl: Option[String])
-    @main(pageInfo, mainScript = Some("thankYouPage.js")) {
+@(pageInfo: PageInfo, social: Set[Social], countryGroup: CountryGroup, charge: Option[String], iosRedirectUrl: Option[String], platform: Option[String])
+    @main(pageInfo, mainScript = Some("thankYouPage.js"), platform = platform) {
     <script type="text/javascript">
         @if(charge.isDefined) {
             guardian.productDetails = {

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -4,7 +4,8 @@
 @(  pageInfo: PageInfo = views.support.PageInfo(),
     countryGroup: Option[CountryGroup] = None,
     maxAmount: Option[Int] = None,
-    mainScript: Option[String] = None
+    mainScript: Option[String] = None,
+    platform: Option[String] = None
 )(content: Html)
 @import play.api.libs.json.Json
 @import configuration.{Config, Social}
@@ -97,6 +98,7 @@
             Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.
         </div>
         <div class="container-global container-global--giraffe">
+            @if(!platform.contains("android")) {
             <header class="global-header hidden-print js-header" role="banner">
                 <div class="global-header__inner">
                     <div class="global-header__branding l-constrained">
@@ -142,6 +144,7 @@
                 </div>
                 @fragments.global.primaryNavigation(pageInfo, false)
             </header>
+            }
 
             <div id="container" class="giraffe-container">
                 @content
@@ -150,6 +153,7 @@
 
         <footer class="global-footer hidden-print global-footer--giraffe" role="contentinfo">
 
+            @if(!platform.contains("android")) {
             <div class="global-brandbar">
                 <div class="global-brandbar__inner l-constrained">
                     <div class="global-brandbar__top">
@@ -167,6 +171,7 @@
                     </div>
                 </div>
             </div>
+            }
 
             <div class="global-footer__info">
                 <div class="global-footer__info__inner l-constrained">


### PR DESCRIPTION
At the moment, when a user visits the contribute page view the app, they see a kind of double header (shown below). In this PR I've tried to use the `platform` query string param we've started sending to remove parts of the template.

This was my first time looking at Twirl templates and I really don't know if this whole approach is right, so I invite robust feedback!

![screenshot_20170316-135827](https://cloud.githubusercontent.com/assets/951849/23999743/248f3050-0a51-11e7-8e8a-8eade6df6c67.png)
