### PR TITLE
Roll out Stripe to 100%

### DIFF
--- a/app/abtests/Test.scala
+++ b/app/abtests/Test.scala
@@ -38,8 +38,10 @@ object Test {
   def cmpCheck(pattern: Regex)(r: Request[_]): Boolean =
     r.getQueryString("INTCMP").exists(pattern.findAllIn(_).nonEmpty)
 
-  val stripeTest = Test("Stripe checkout", 100.percent, 0.percent, Seq(Variant("control"), Variant("stripe")))
+
+  val stripeTest = Test("Stripe checkout", 100.percent, 0.percent, Seq(Variant("stripe")))
   val landingPageTest = Test("Landing page", 100.percent, 0.percent, Seq(Variant("control"), Variant("with-copy")), cmpCheck("cont_.*_banner".r))
+
   val allTests: Set[Test] = Set(stripeTest, landingPageTest)
 
   def slugify(s: String): String = slugifier.slugify(s)

--- a/app/abtests/Test.scala
+++ b/app/abtests/Test.scala
@@ -38,9 +38,8 @@ object Test {
   def cmpCheck(pattern: Regex)(r: Request[_]): Boolean =
     r.getQueryString("INTCMP").exists(pattern.findAllIn(_).nonEmpty)
 
-
   val stripeTest = Test("Stripe checkout", 100.percent, 0.percent, Seq(Variant("stripe")))
-  val landingPageTest = Test("Landing page", 100.percent, 0.percent, Seq(Variant("control"), Variant("with-copy")), cmpCheck("cont_.*_banner".r))
+  val landingPageTest = Test("Landing page", 100.percent, 0.percent, Seq(Variant("with-copy")), cmpCheck("cont_.*_banner".r))
 
   val allTests: Set[Test] = Set(stripeTest, landingPageTest)
 


### PR DESCRIPTION
This releases the Stripe checkout flow to everyone. Although this performed 3.8% worse than the control, we are releasing it now to avoid any danger of being fined for not meeting PCI compliance, and will prioritise implementing [Stripe Elements](https://stripe.com/docs/elements) (which will allow us to keep the original design and be PCI compliant) in an upcoming sprint. 

@guardian/contributions 