### PR TITLE
Refactor Test class to allow for canRun checks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,7 +54,7 @@ module.exports = function (grunt) {
             options: isDev ? require('./webpack.config.js') : require('./webpack.config.prod.js'),
             frontend: {
                 output: {
-                    path: 'public/',
+                    path: require('path').resolve(__dirname, 'public'),
                     chunkFilename:  'webpack/[chunkhash].js',
                     filename: "javascripts/[name].js",
                     publicPath: '/assets/'

--- a/app/abtests/Test.scala
+++ b/app/abtests/Test.scala
@@ -10,12 +10,7 @@ case class Percentage(value: Double) {
   def of[B](x: B)(implicit numB: Numeric[B]): Double = numB.toDouble(x) / 100 * value
 }
 
-sealed trait Test {
-  val name: String
-  val audienceSize: Percentage
-  val audienceOffset: Percentage
-  val variants: Iterable[Variant]
-
+case class Test(name: String, audienceSize: Percentage, audienceOffset: Percentage, variants: Seq[Variant], canRun: Request[_] => Boolean = _ => true) {
   val startId: Int = audienceOffset.of(Test.maxTestId).toInt
   val endId: Int = startId + audienceSize.of(Test.maxTestId).toInt
   val idRange: Range = startId.to(endId).tail
@@ -23,19 +18,10 @@ sealed trait Test {
   val slug: String = Test.slugify(name)
   val cookieName: String = s"${Test.cookiePrefix}.${slug}"
 
-  def canRun(req: Request[_]): Boolean
-
   def allocate(id: Int, request: Request[_]): Option[Allocation] = {
     if (idRange.contains(id) && canRun(request)) Some(Allocation(this, variants.toList(id % variants.size)))
     else None
   }
-}
-
-case class SplitTest(name: String, audienceSize: Percentage, audienceOffset: Percentage, variants: Variant*) extends Test {
-  override def canRun(req: Request[_]): Boolean = true
-}
-case class ConditionalTest(name: String, audienceSize: Percentage, audienceOffset: Percentage, canRunCheck: Request[_] => Boolean, variants: Variant*) extends Test {
-  override def canRun(req: Request[_]): Boolean = canRunCheck(req)
 }
 
 object Test {
@@ -52,8 +38,8 @@ object Test {
   def cmpCheck(pattern: Regex)(r: Request[_]): Boolean =
     r.getQueryString("INTCMP").exists(pattern.findAllIn(_).nonEmpty)
 
-  val stripeTest = SplitTest("Stripe checkout", 100.percent, 0.percent, Variant("control"), Variant("stripe"))
-  val landingPageTest = ConditionalTest("Landing page", 100.percent, 0.percent, cmpCheck("mem_.*_banner".r), Variant("control"), Variant("with-copy"))
+  val stripeTest = Test("Stripe checkout", 100.percent, 0.percent, Seq(Variant("control"), Variant("stripe")))
+  val landingPageTest = Test("Landing page", 100.percent, 0.percent, Seq(Variant("control"), Variant("with-copy")), cmpCheck("mem_.*_banner".r))
   val allTests: Set[Test] = Set(stripeTest, landingPageTest)
 
   def slugify(s: String): String = slugifier.slugify(s)

--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -32,6 +32,7 @@ object CommonActions {
 
   case class ABTestRequest[A](testId: Int, request: Request[A]) extends WrappedRequest(request) {
     val testAllocations = Test.allocations(testId, request)
+    def isAllocated(test: Test, variantName: String) = testAllocations.exists(a => a.test == test && a.variant.name == variantName)
   }
 
   object ABTestAction extends ActionBuilder[ABTestRequest] {

--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -31,7 +31,7 @@ object CommonActions {
   }
 
   case class ABTestRequest[A](testId: Int, request: Request[A]) extends WrappedRequest(request) {
-    val testAllocations = Test.allocations(testId)
+    val testAllocations = Test.allocations(testId, request)
   }
 
   object ABTestAction extends ActionBuilder[ABTestRequest] {

--- a/test/TestCheck.scala
+++ b/test/TestCheck.scala
@@ -1,27 +1,48 @@
 package abtests
 
 import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop.{BooleanOperators, forAll}
 import org.scalacheck.{Arbitrary, Gen, Properties}
-import org.scalacheck.Prop.forAll
+import play.api.mvc.Request
+import play.api.test.FakeRequest
 
 object ABTestSpec extends Properties("test") {
   val testIdGen = Gen.posNum[Int].suchThat(i => i > 0 && i <= Test.maxTestId)
+  val fakeRequest: Request[_] = FakeRequest()
 
   implicit val ap: Arbitrary[Percentage] = Arbitrary(Gen.posNum[Double].suchThat(_ <= 100).map(Percentage))
   implicit val av: Arbitrary[Variant] = Arbitrary(Gen.alphaStr.map(Variant))
-  implicit val at: Arbitrary[Test] = Arbitrary(for {
+
+  implicit val at: Arbitrary[SplitTest] = Arbitrary(for {
     name <- Gen.alphaStr
     audienceSize <- arbitrary[Percentage]
     audienceOffset <- arbitrary[Percentage]
     variants <- Gen.nonEmptyContainerOf[Seq, Variant](arbitrary[Variant])
-  } yield Test(name, audienceSize, audienceOffset, variants: _*))
+  } yield SplitTest(name, audienceSize, audienceOffset, variants: _*))
 
-  property("test allocation covers IDs correctly") = forAll { (test: Test) =>
-    test.idRange.forall(id => test.allocate(id).nonEmpty) &&
-    (1 to Test.maxTestId).diff(test.idRange).forall(id => test.allocate(id).isEmpty)
+  implicit val act: Arbitrary[ConditionalTest] = Arbitrary(for {
+    t <- arbitrary[SplitTest]
+    canRun <- arbitrary[Boolean]
+  } yield ConditionalTest(t.name, t.audienceSize, t.audienceOffset, _ => canRun, t.variants: _*))
+
+  property("split test allocation covers IDs correctly") = forAll { (test: SplitTest) =>
+    test.idRange.forall(id => test.allocate(id, fakeRequest).nonEmpty) &&
+      (1 to Test.maxTestId).diff(test.idRange).forall(id => test.allocate(id, fakeRequest).isEmpty)
   }
 
-  property("test allocation assigns all variants") = forAll { (test: Test) =>
-    test.idRange.flatMap(id => test.allocate(id)).map(_.variant).toSet == test.variants.toSet
+  property("split test allocation assigns all variants") = forAll { (test: SplitTest) =>
+    test.idRange.flatMap(id => test.allocate(id, fakeRequest)).map(_.variant).toSet == test.variants.toSet
+  }
+
+  property("conditional test allocation covers IDs and canRun conditions correctly") = forAll { (test: ConditionalTest) =>
+    test.idRange.forall(id => test.allocate(id, fakeRequest).nonEmpty == test.canRun(fakeRequest)) &&
+      (1 to Test.maxTestId).diff(test.idRange).forall(id => test.allocate(id, fakeRequest).isEmpty)
+  }
+
+  property("conditional test allocation assigns all variants") = forAll { (test: ConditionalTest) =>
+    val allocatedVariants = test.idRange.flatMap(id => test.allocate(id, fakeRequest)).map(_.variant).toSet
+
+    test.canRun(fakeRequest) ==> (allocatedVariants == test.variants.toSet) ||
+      !test.canRun(fakeRequest) ==> (allocatedVariants == Set.empty)
   }
 }

--- a/test/TestCheck.scala
+++ b/test/TestCheck.scala
@@ -13,33 +13,19 @@ object ABTestSpec extends Properties("test") {
   implicit val ap: Arbitrary[Percentage] = Arbitrary(Gen.posNum[Double].suchThat(_ <= 100).map(Percentage))
   implicit val av: Arbitrary[Variant] = Arbitrary(Gen.alphaStr.map(Variant))
 
-  implicit val at: Arbitrary[SplitTest] = Arbitrary(for {
+  implicit val at: Arbitrary[Test] = Arbitrary(for {
     name <- Gen.alphaStr
     audienceSize <- arbitrary[Percentage]
     audienceOffset <- arbitrary[Percentage]
     variants <- Gen.nonEmptyContainerOf[Seq, Variant](arbitrary[Variant])
-  } yield SplitTest(name, audienceSize, audienceOffset, variants: _*))
-
-  implicit val act: Arbitrary[ConditionalTest] = Arbitrary(for {
-    t <- arbitrary[SplitTest]
     canRun <- arbitrary[Boolean]
-  } yield ConditionalTest(t.name, t.audienceSize, t.audienceOffset, _ => canRun, t.variants: _*))
+  } yield Test(name, audienceSize, audienceOffset, variants, _ => canRun))
 
-  property("split test allocation covers IDs correctly") = forAll { (test: SplitTest) =>
-    test.idRange.forall(id => test.allocate(id, fakeRequest).nonEmpty) &&
-      (1 to Test.maxTestId).diff(test.idRange).forall(id => test.allocate(id, fakeRequest).isEmpty)
+  property("test allocation covers IDs and canRun conditions correctly") = forAll { (test: Test) =>
+    test.idRange.forall(id => test.allocate(id, fakeRequest).nonEmpty == test.canRun(fakeRequest))
   }
 
-  property("split test allocation assigns all variants") = forAll { (test: SplitTest) =>
-    test.idRange.flatMap(id => test.allocate(id, fakeRequest)).map(_.variant).toSet == test.variants.toSet
-  }
-
-  property("conditional test allocation covers IDs and canRun conditions correctly") = forAll { (test: ConditionalTest) =>
-    test.idRange.forall(id => test.allocate(id, fakeRequest).nonEmpty == test.canRun(fakeRequest)) &&
-      (1 to Test.maxTestId).diff(test.idRange).forall(id => test.allocate(id, fakeRequest).isEmpty)
-  }
-
-  property("conditional test allocation assigns all variants") = forAll { (test: ConditionalTest) =>
+  property("test allocation assigns all variants") = forAll { (test: Test) =>
     val allocatedVariants = test.idRange.flatMap(id => test.allocate(id, fakeRequest)).map(_.variant).toSet
 
     test.canRun(fakeRequest) ==> (allocatedVariants == test.variants.toSet) ||


### PR DESCRIPTION
In addition to audience segmentation, you can now create tests with or without can run criteria, which I've called "split tests" and "conditional tests". The can run check is a boolean function that takes a request as its only parameter. I figure this should be enough for most use cases.

@guardian/contributions 