### PR TITLE
Fix landing page test campaign code

### DIFF
--- a/app/abtests/Test.scala
+++ b/app/abtests/Test.scala
@@ -39,7 +39,7 @@ object Test {
     r.getQueryString("INTCMP").exists(pattern.findAllIn(_).nonEmpty)
 
   val stripeTest = Test("Stripe checkout", 100.percent, 0.percent, Seq(Variant("control"), Variant("stripe")))
-  val landingPageTest = Test("Landing page", 100.percent, 0.percent, Seq(Variant("control"), Variant("with-copy")), cmpCheck("mem_.*_banner".r))
+  val landingPageTest = Test("Landing page", 100.percent, 0.percent, Seq(Variant("control"), Variant("with-copy")), cmpCheck("cont_.*_banner".r))
   val allTests: Set[Test] = Set(stripeTest, landingPageTest)
 
   def slugify(s: String): String = slugifier.slugify(s)


### PR DESCRIPTION
`mem_uk_banner` is only used for membership links, so this test wouldn't
have been allocating anyone. 