### PR TITLE
App pay endpoint

### DIFF
--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -229,7 +229,6 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
     )(AppContributionRequest.apply _)
   }
 
-
   def appPay = NoCacheAction.async(BodyParsers.parse.json[AppContributionRequest]) { request =>
     val stripe = paymentServices.stripeServiceFor(request)
 

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -48,22 +48,21 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
   }
 
   case class SupportForm(
-                          name: String,
-                          currency: Currency,
-                          amount: BigDecimal,
-                          email: String,
-                          token: String,
-                          marketing: Boolean,
-                          postcode: Option[String],
-                          abTests: Set[JsonAbTest],
-                          ophanPageviewId: String,
-                          ophanBrowserId: Option[String],
-                          cmp: Option[String],
-                          intcmp: Option[String],
-                          refererPageviewId: Option[String],
-                          refererUrl: Option[String]
-
-                        )
+    name: String,
+    currency: Currency,
+    amount: BigDecimal,
+    email: String,
+    token: String,
+    marketing: Boolean,
+    postcode: Option[String],
+    abTests: Set[JsonAbTest],
+    ophanPageviewId: String,
+    ophanBrowserId: Option[String],
+    cmp: Option[String],
+    intcmp: Option[String],
+    refererPageviewId: Option[String],
+    refererUrl: Option[String]
+  )
 
   val supportForm: Form[SupportForm] = Form(
     mapping(

--- a/conf/routes
+++ b/conf/routes
@@ -22,6 +22,7 @@ POST           /:countryGroup/update-metadata   controllers.PaypalController.upd
 
 POST           /stripe/pay                      controllers.StripeController.pay
 POST           /stripe/hook                     controllers.StripeController.hook
+POST           /stripe/app-pay                  controllers.StripeController.appPay
 
 GET            /ca                              controllers.Contributions.redirectToUk
 GET            /nz                              controllers.Contributions.redirectToUk


### PR DESCRIPTION
Adds a new endpoint at `/stripe/app-pay` routed to `StripeController.appPay` which accepts a JSON-formatted payment request from one of the native apps and handles it.

I'm opening this PR to get some feedback on what I've done so far, knowing that it is not a complete piece of work (no tests for example), in order to get some feedback, because I am new to this codebase in particular and the Play framework in general.