### PR TITLE
Support pay endpoint with JSON (for Apps)

### DIFF
--- a/app/controllers/BodyParsers.scala
+++ b/app/controllers/BodyParsers.scala
@@ -1,0 +1,36 @@
+package controllers
+
+import play.api.data.Form
+import play.api.mvc.BodyParsers.parse
+import play.api.mvc.{BodyParser, Results}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object BodyParsers {
+
+  // this applies the constraints of a form on a JSON payload
+  def jsonFormBodyParser[A](form: Form[A])(implicit ec: ExecutionContext): BodyParser[A] = BodyParser { requestHeader =>
+    parse.anyContent(None)(requestHeader).map { resultOrBody =>
+      resultOrBody.right.flatMap { body =>
+        body.asJson.map(json => form.bind(json)
+          .fold(_ => Left(Results.BadRequest), a => Right(a)))
+          .getOrElse(Left(Results.BadRequest))
+      }
+    }
+  }
+
+  /**
+    * Takes a form, either as a multipart post, or as a json payload
+    * @param form the form to parse (will respect format constraint, even in json)
+    * @tparam A the result type
+    * @return a body parser
+    */
+  def jsonOrMultipart[A](form: Form[A])(implicit ec: ExecutionContext): BodyParser[A] = parse.using { request =>
+    request.contentType match {
+      case Some("multipart/form-data") => parse.form(form)
+      case Some("application/json") => jsonFormBodyParser(form)
+      case _ => parse.error(Future.successful(Results.BadRequest))
+    }
+  }
+
+}

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -156,7 +156,7 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
     Redirect(routes.Contributions.contribute(countryGroup, Some(PaypalError)).url, SEE_OTHER)
   }
 
-  def hook = NoCacheAction.async(BodyParsers.parse.tolerantText) { request =>
+  def hook = NoCacheAction.async(parse.tolerantText) { request =>
     val bodyText = request.body
     val bodyJson = Json.parse(request.body)
 

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -40,7 +40,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
       Map(key -> value.identifier)
   }
 
-  case class SupportForm(
+  case class ContributionRequest(
     name: String,
     currency: Currency,
     amount: BigDecimal,
@@ -57,7 +57,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
 
   )
 
-  val supportForm: Form[SupportForm] = Form(
+  val contributionForm: Form[ContributionRequest] = Form(
     mapping(
       "name" -> text,
       "currency" -> of[Currency],
@@ -72,10 +72,10 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
       "intcmp" -> optional(text),
       "refererPageviewId" -> optional(text),
       "refererUrl" -> optional(text)
-    )(SupportForm.apply)(SupportForm.unapply)
+    )(ContributionRequest.apply)(ContributionRequest.unapply)
   )
 
-  def pay = (NoCacheAction andThen MobileSupportAction andThen ABTestAction).async(parse.form(supportForm)) { implicit request =>
+  def pay = (NoCacheAction andThen MobileSupportAction andThen ABTestAction).async(parse.form(contributionForm)) { implicit request =>
 
     val form = request.body
 

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -6,8 +6,6 @@ import java.time.Instant
 import actions.CommonActions._
 import cats.data.EitherT
 import cats.syntax.show._
-import cookies.ContribTimestampCookieAttributes
-import cookies.syntax._
 import com.gu.i18n.CountryGroup._
 import com.gu.i18n.{AUD, Currency, EUR, USD}
 import com.gu.stripe.Stripe
@@ -15,12 +13,13 @@ import com.gu.stripe.Stripe.Charge
 import com.gu.stripe.Stripe.Serializer._
 import com.typesafe.config.Config
 import cookies.ContribTimestampCookieAttributes
+import cookies.syntax._
 import models._
 import org.joda.time.DateTime
 import play.api.Logger
-import play.api.data.{Form, FormError}
 import play.api.data.Forms._
 import play.api.data.format.Formatter
+import play.api.data.{Form, FormError}
 import play.api.libs.json.{JsError, JsSuccess, JsValue, Json}
 import play.api.mvc.{BodyParsers, Controller, Result}
 import services.PaymentServices
@@ -30,7 +29,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(implicit ec: ExecutionContext)
   extends Controller with Redirect {
-  import ContribTimestampCookieAttributes._
 
   implicit val currencyFormatter = new Formatter[Currency] {
     type Result = Either[Seq[FormError], Currency]

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -35,7 +35,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
     val form = request.body
 
     val stripe = paymentServices.stripeServiceFor(request)
-    val idUser = IdentityId.fromRequest(request)
+    val idUser = IdentityId.fromRequest(request) orElse form.idUser
 
     val countryGroup = form.currency match {
       case USD => US

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -42,12 +42,6 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
       Map(key -> value.identifier)
   }
 
-  case class JsonAbTest(testName: String, testSlug: String, variantName: String, variantSlug: String)
-
-  object JsonAbTest {
-    implicit val abTestFormat = Json.format[JsonAbTest]
-  }
-
   case class SupportForm(
     name: String,
     currency: Currency,
@@ -56,7 +50,6 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
     token: String,
     marketing: Boolean,
     postcode: Option[String],
-    abTests: Set[JsonAbTest],
     ophanPageviewId: String,
     ophanBrowserId: Option[String],
     cmp: Option[String],
@@ -75,12 +68,6 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
       "token" -> nonEmptyText,
       "marketing" -> boolean,
       "postcode" -> optional(nonEmptyText),
-      "abTests" -> set(mapping(
-        "testName" -> text,
-        "testSlug" -> text,
-        "variantName" -> text,
-        "variantSlug" -> text
-      )(JsonAbTest.apply)(JsonAbTest.unapply)),
       "ophanPageviewId" -> text,
       "ophanBrowserId" -> optional(text),
       "cmp" -> optional(text),

--- a/app/controllers/forms/ContributionRequest.scala
+++ b/app/controllers/forms/ContributionRequest.scala
@@ -1,0 +1,57 @@
+package controllers.forms
+
+import com.gu.i18n.Currency
+import play.api.data.{Form, FormError}
+import play.api.data.format.Formatter
+
+// THIS CASE CLASS IS USED BY THE FRONTEND AS A FORM, AND BY THE MOBILE APPS AS A JSON POST
+// NEW FIELDS SHOULD BE OPTIONAL OR SUPPORTED BY BOTH
+case class ContributionRequest(
+  name: String,
+  currency: Currency,
+  amount: BigDecimal,
+  email: String,
+  token: String,
+  marketing: Boolean,
+  postcode: Option[String],
+  ophanPageviewId: String,
+  ophanBrowserId: Option[String],
+  cmp: Option[String],
+  intcmp: Option[String],
+  refererPageviewId: Option[String],
+  refererUrl: Option[String]
+)
+
+object ContributionRequest {
+  import play.api.data.Forms._
+  implicit val currencyFormatter = new Formatter[Currency] {
+    type Result = Either[Seq[FormError], Currency]
+
+    override def bind(key: String, data: Map[String, String]): Result =
+      data.get(key).map(_.toUpperCase).flatMap(Currency.fromString).fold[Result](Left(Seq.empty))(currency => Right(currency))
+
+    override def unbind(key: String, value: Currency): Map[String, String] =
+      Map(key -> value.identifier)
+  }
+
+  val contributionForm: Form[ContributionRequest] = Form(
+    mapping(
+      "name" -> text,
+      "currency" -> of[Currency],
+      "amount" -> bigDecimal(10, 2),
+      "email" -> email,
+      "token" -> nonEmptyText,
+      "marketing" -> boolean,
+      "postcode" -> optional(nonEmptyText),
+      "ophanPageviewId" -> text,
+      "ophanBrowserId" -> optional(text),
+      "cmp" -> optional(text),
+      "intcmp" -> optional(text),
+      "refererPageviewId" -> optional(text),
+      "refererUrl" -> optional(text)
+    )(ContributionRequest.apply)(ContributionRequest.unapply)
+  )
+
+}
+
+

--- a/app/controllers/forms/ContributionRequest.scala
+++ b/app/controllers/forms/ContributionRequest.scala
@@ -1,6 +1,7 @@
 package controllers.forms
 
 import com.gu.i18n.Currency
+import models.IdentityId
 import play.api.data.{Form, FormError}
 import play.api.data.format.Formatter
 
@@ -19,7 +20,8 @@ case class ContributionRequest(
   cmp: Option[String],
   intcmp: Option[String],
   refererPageviewId: Option[String],
-  refererUrl: Option[String]
+  refererUrl: Option[String],
+  idUser: Option[IdentityId]
 )
 
 object ContributionRequest {
@@ -32,6 +34,12 @@ object ContributionRequest {
 
     override def unbind(key: String, value: Currency): Map[String, String] =
       Map(key -> value.identifier)
+  }
+
+  implicit val identityIdFormatter = new Formatter[IdentityId] {
+    override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], IdentityId] =
+      data.get(key).map(IdentityId.apply).toRight(Seq(FormError(key, s"Unable to fin the key $key in the form")))
+    override def unbind(key: String, value: IdentityId): Map[String, String] = Map(key -> value.id)
   }
 
   val contributionForm: Form[ContributionRequest] = Form(
@@ -48,7 +56,8 @@ object ContributionRequest {
       "cmp" -> optional(text),
       "intcmp" -> optional(text),
       "refererPageviewId" -> optional(text),
-      "refererUrl" -> optional(text)
+      "refererUrl" -> optional(text),
+      "idUser" -> optional(of[IdentityId])
     )(ContributionRequest.apply)(ContributionRequest.unapply)
   )
 


### PR DESCRIPTION
In order to test the conversion of our app users using a native flow, we need an endpoint capable of ingesting json.
I'm transforming the /stripe/pay endpoint to be able to handle both a form and a json payload.

That really means the /stripe/pay endpoint will be used by both the apps and the frontend, and we need to think twice before drastically changing its behaviour (but adding more optional fields is fine!)

It's easier to read this PR commit per commit.

@guardian/contributions 

cc @maxspencer 