### PR TITLE
increase gap between contribution count and line below

### DIFF
--- a/assets/stylesheets/contributions.scss
+++ b/assets/stylesheets/contributions.scss
@@ -674,10 +674,10 @@ $currencies: gbp usd aud eur nzd cad;
         line-height: 1;
         font-weight: 900;
         margin-bottom: 0;
-        margin-top: -8px;
+        margin-top: -6px;
         @include mq(tablet) {
             font-size: 24px;
-            margin-top: -18px;
+            margin-top: -12px;
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a slight edit to the CSS in #256.

When the contribution count is smaller (than the hard coded 10,000) the vertical height between the comma in the number, and the text below is too small (as illustrated below).

<img width="595" alt="css-edit" src="https://cloud.githubusercontent.com/assets/4085817/25481987/a7be5aca-2b47-11e7-91fa-6d3a3163f588.png">

It now looks like this:

<img width="611" alt="css-fix" src="https://cloud.githubusercontent.com/assets/4085817/25482111/208bb2ea-2b48-11e7-891e-5f8436741433.png">
