### PR TITLE
Re-remove control variants for the stripe and landing page

### DIFF
--- a/app/abtests/Test.scala
+++ b/app/abtests/Test.scala
@@ -47,7 +47,7 @@ object Test {
 
   val stripeTest = Test("Stripe checkout", 100.percent, 0.percent, Seq(Variant("stripe")))
 
-  val landingPageTest = Test("Landing page", 100.percent, 0.percent, Seq(Variant("control"), Variant("with-copy")), cmpCheck("cont_.*_banner".r))
+  val landingPageTest = Test("Landing page", 100.percent, 0.percent, Seq(Variant("with-copy")), cmpCheck("cont_.*_banner".r))
 
   object HumaniseTestV2 {
     import Variants._

--- a/app/abtests/Test.scala
+++ b/app/abtests/Test.scala
@@ -45,7 +45,7 @@ object Test {
   def cmpCheck(pattern: Regex)(r: Request[_]): Boolean =
     r.getQueryString("INTCMP").exists(pattern.findAllIn(_).nonEmpty)
 
-  val stripeTest = Test("Stripe checkout", 100.percent, 0.percent, Seq(Variant("control"), Variant("stripe")))
+  val stripeTest = Test("Stripe checkout", 100.percent, 0.percent, Seq(Variant("stripe")))
 
   val landingPageTest = Test("Landing page", 100.percent, 0.percent, Seq(Variant("control"), Variant("with-copy")), cmpCheck("cont_.*_banner".r))
 


### PR DESCRIPTION
@guardian/contributions 

I accidentally re-added the control variants for the stripe and landing page tests [here](https://github.com/guardian/contributions-frontend/pull/256/commits/9bc1583fa8dff2d501a23f455dfafc92c2f007ea). 

Neither of them should be included as they were removed in #242 

This pull request re-removes them.


