### PR TITLE
Fix phony complete event on PayPal errors

### DIFF
--- a/assets/javascripts/src/actions.es6
+++ b/assets/javascripts/src/actions.es6
@@ -97,7 +97,7 @@ export function paypalRedirect(dispatch) {
         if (response.ok) {
             return response.json();
         } else {
-            dispatch({ type: PAYMENT_ERROR, kind: 'paypal', error: {message: 'Sorry, an error occurred, please try again or use another payment method.' }})
+            throw response;
         }
     })
     .then(response => {


### PR DESCRIPTION
By `throw`ing here we won't continue with any of the remaining promise chain, which includes the completion call.