### PR TITLE
Don't duplicate card entry on mobile

### DIFF
--- a/assets/javascripts/src/components/form-wrapper/MobileWrapper.jsx
+++ b/assets/javascripts/src/components/form-wrapper/MobileWrapper.jsx
@@ -12,7 +12,7 @@ export default class MobileWrapper extends React.Component {
         if (this.props.page == PAGES.CONTRIBUTION)
             return this.renderInForm([PAGES.CONTRIBUTION]);
         else
-            return this.renderInForm([PAGES.DETAILS, PAGES.PAYMENT]);
+            return this.renderInForm([PAGES.DETAILS]);
 
     }
 


### PR DESCRIPTION
Since we're taking payment via the Stripe popup for everyone, we shouldn't have our payment details form displaying at all.

It was correctly disabled on desktop, but not on mobile. So mobile users would enter their card details, click pay, then have to re-enter in the Stripe popup

# before
![picture 560](https://cloud.githubusercontent.com/assets/5122968/25901809/c666e31e-358f-11e7-896d-b07264cbf80e.png)

# after
![picture 561](https://cloud.githubusercontent.com/assets/5122968/25901827/d53511ea-358f-11e7-9bdb-bae72b3d9fe3.png)

@desbo 
