### PR TITLE
Fix squashed mobile view by making gutters consistent

### DIFF
--- a/assets/stylesheets/_vars.scss
+++ b/assets/stylesheets/_vars.scss
@@ -270,3 +270,7 @@ $font-scale: (
 
 $tablet-form-width: map_get($max-widths, max-tablet);
 $desktop-form-width: 936px;
+
+$mobile-gutter: $gs-gutter / 2;
+$tablet-gutter: $gs-gutter;
+$mem-full-gutter: $gs-gutter * 2;

--- a/assets/stylesheets/components/_global-footer.scss
+++ b/assets/stylesheets/components/_global-footer.scss
@@ -50,7 +50,7 @@
    padding: $mobile-gutter;
 
    @include mq(tablet) {
-       padding: ($gs-gutter / 2) $tablet-gutter $gs-baseline;
+       padding: $gs-baseline $tablet-gutter;
    }
 }
 .global-brandbar__top {

--- a/assets/stylesheets/components/_global-footer.scss
+++ b/assets/stylesheets/components/_global-footer.scss
@@ -16,10 +16,14 @@
     }
 }
 .global-footer__info__inner {
-    padding: ($gs-baseline * 2) ($gs-gutter / 2);
+    padding: ($gs-baseline * 2) $mobile-gutter;
 
     @include mq(tablet) {
-        padding: ($gs-baseline * 2) $gs-gutter;
+        padding: ($gs-baseline * 2) $tablet-gutter;
+    }
+
+    @include mq(mem-full) {
+        padding: ($gs-baseline * 2) $mem-full-gutter;
     }
 }
 .global-footer__copyright {
@@ -47,11 +51,15 @@
 }
 .global-brandbar__inner {
    @include clearfix();
-   padding: ($gs-gutter / 2) ($gs-gutter / 4);
+   padding: $mobile-gutter;
 
    @include mq(tablet) {
-       padding: ($gs-gutter / 2) ($gs-gutter / 2) $gs-baseline
+       padding: ($gs-gutter / 2) $tablet-gutter $gs-baseline;
    }
+
+    @include mq(mem-full) {
+        padding: ($gs-gutter / 2) $mem-full-gutter $gs-baseline;
+    }
 }
 .global-brandbar__top {
     float: left;

--- a/assets/stylesheets/components/_global-footer.scss
+++ b/assets/stylesheets/components/_global-footer.scss
@@ -21,10 +21,6 @@
     @include mq(tablet) {
         padding: ($gs-baseline * 2) $tablet-gutter;
     }
-
-    @include mq(mem-full) {
-        padding: ($gs-baseline * 2) $mem-full-gutter;
-    }
 }
 .global-footer__copyright {
     @include fs-textSans(1);
@@ -56,10 +52,6 @@
    @include mq(tablet) {
        padding: ($gs-gutter / 2) $tablet-gutter $gs-baseline;
    }
-
-    @include mq(mem-full) {
-        padding: ($gs-gutter / 2) $mem-full-gutter $gs-baseline;
-    }
 }
 .global-brandbar__top {
     float: left;

--- a/assets/stylesheets/components/_global-header.scss
+++ b/assets/stylesheets/components/_global-header.scss
@@ -30,11 +30,15 @@ $global-header-height-mobile: 116px;
 }
 .global-header__branding {
     @include clearfix();
-    padding: ($gs-gutter / 2);
+    padding: $mobile-gutter;
     padding-bottom: $gs-gutter;
 
     @include mq(tablet) {
-        padding: ($gs-gutter / 2) $gs-gutter;
+        padding: ($gs-gutter / 2) $tablet-gutter;
+    }
+
+    @include mq(mem-full) {
+        padding: ($gs-gutter / 2) $mem-full-gutter;
     }
 }
 .global-header__primary {

--- a/assets/stylesheets/components/_global-header.scss
+++ b/assets/stylesheets/components/_global-header.scss
@@ -36,10 +36,6 @@ $global-header-height-mobile: 116px;
     @include mq(tablet) {
         padding: ($gs-gutter / 2) $tablet-gutter;
     }
-
-    @include mq(mem-full) {
-        padding: ($gs-gutter / 2) $mem-full-gutter;
-    }
 }
 .global-header__primary {
     float: left;

--- a/assets/stylesheets/components/_global-header.scss
+++ b/assets/stylesheets/components/_global-header.scss
@@ -34,7 +34,7 @@ $global-header-height-mobile: 116px;
     padding-bottom: $gs-gutter;
 
     @include mq(tablet) {
-        padding: ($gs-gutter / 2) $tablet-gutter;
+        padding: $gs-baseline $tablet-gutter;
     }
 }
 .global-header__primary {

--- a/assets/stylesheets/components/_navigation.scss
+++ b/assets/stylesheets/components/_navigation.scss
@@ -56,9 +56,6 @@
     @include mq(desktop) {
         width: 100%;
     }
-    @include mq(mem-full) {
-        padding: 0 $mem-full-gutter;
-    }
 }
 .global-navigation__list {
     margin: 0;

--- a/assets/stylesheets/components/_navigation.scss
+++ b/assets/stylesheets/components/_navigation.scss
@@ -47,14 +47,17 @@
     width: auto;
     vertical-align: middle;
     height: $global-toggle-height;
-    padding: 0 ($global-toggle-height * 2) 0 ($gs-gutter / 2);
+    padding: 0 ($global-toggle-height * 2) 0 $mobile-gutter;
 
     @include mq(tablet) {
-        padding: 0 $gs-gutter;
+        padding: 0 $tablet-gutter;
         display: block;
     }
     @include mq(desktop) {
         width: 100%;
+    }
+    @include mq(mem-full) {
+        padding: 0 $mem-full-gutter;
     }
 }
 .global-navigation__list {

--- a/assets/stylesheets/contributions.scss
+++ b/assets/stylesheets/contributions.scss
@@ -163,11 +163,16 @@ $control-spacing: 5px;
 
 .contributions__inner,
 .feedback {
-    padding: 0 $gs-gutter $gs-baseline;
+    padding: 0 $mobile-gutter $gs-baseline;
+
+    @include mq(tablet) {
+        padding-left: $tablet-gutter;
+        padding-right: $tablet-gutter;
+    }
 
     @include mq(mem-full) {
-        padding-left: $gs-gutter * 2;
-        padding-right: $gs-gutter * 2;
+        padding-left: $mem-full-gutter;
+        padding-right: $mem-full-gutter;
     }
 }
 


### PR DESCRIPTION
At mobile width the body was too narrow, meaning there wasn't enough room for the button arrows. I've made the body gutters consistent with the header, which fixes the issue.

While I was there I also tidied things a bit by making `$gs-baseline` the unit for vertical spacing (gutter should refer to horizontal spacing only)

# before
![picture 570](https://cloud.githubusercontent.com/assets/5122968/25944958/0d2c0e16-363d-11e7-9809-cdfb33644e61.png)

# after
![picture 569](https://cloud.githubusercontent.com/assets/5122968/25944970/180996f0-363d-11e7-9a2f-b093e855bf05.png)

@desbo
