### PR TITLE
Engagement banner campaign code check updated

### DIFF
--- a/app/abtests/Test.scala
+++ b/app/abtests/Test.scala
@@ -47,7 +47,7 @@ object Test {
 
   val stripeTest = Test("Stripe checkout", 100.percent, 0.percent, Seq(Variant("stripe")))
 
-  val landingPageTest = Test("Landing page", 100.percent, 0.percent, Seq(Variant("with-copy")), cmpCheck("cont_.*_banner".r))
+  val landingPageTest = Test("Landing page", 100.percent, 0.percent, Seq(Variant("with-copy")), cmpCheck("gdnwb_copts.*_banner".r))
 
   val allTests: Set[Test] = Set(stripeTest, landingPageTest)
 


### PR DESCRIPTION
cc @guardian/contributions 

When a reader views the contributions landing page, they are shown an Epic-like variant __iff__ they have come from the engagement banner. This is established by checking the `INTCMP` query string field.

This pull request updates the check on the campaign code as it is changed in [this](https://github.com/guardian/frontend/pull/16693#pullrequestreview-37508061) pull request.

Landing page with no `INTCMP` field:

<img width="1273" alt="default_landing_page" src="https://cloud.githubusercontent.com/assets/4085817/25945751/00b88e0e-3640-11e7-8a03-fd44972c356f.png">

Landing page with `INTCMP=gdnwb_copts_memco_banner`:

<img width="1277" alt="engagement_banner_landing_page" src="https://cloud.githubusercontent.com/assets/4085817/25945774/13482386-3640-11e7-8bdd-35e01e10f420.png">

Landing page with `INTCMP=gdnwb_copts_memco_epic`:

<img width="1273" alt="default_landing_page" src="https://cloud.githubusercontent.com/assets/4085817/25945751/00b88e0e-3640-11e7-8a03-fd44972c356f.png">

