### PR TITLE
Add functionality to tag logs

### DIFF
--- a/app/abtests/Test.scala
+++ b/app/abtests/Test.scala
@@ -2,7 +2,7 @@ package abtests
 
 import actions.CommonActions.ABTestRequest
 import com.github.slugify.Slugify
-import play.api.Logger
+import monitoring.{SentryTagLogger => Logger}
 import play.api.db.Database
 import play.api.libs.json.{JsValue, Json, Writes}
 import play.api.mvc.AnyContent

--- a/app/abtests/Test.scala
+++ b/app/abtests/Test.scala
@@ -2,7 +2,6 @@ package abtests
 
 import actions.CommonActions.ABTestRequest
 import com.github.slugify.Slugify
-import monitoring.{SentryTagLogger => Logger}
 import play.api.db.Database
 import play.api.libs.json.{JsValue, Json, Writes}
 import play.api.mvc.AnyContent

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -2,11 +2,8 @@ package configuration
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import com.typesafe.config.ConfigFactory
-import play.api.Logger
 
 object Config {
-
-  val logger = Logger(this.getClass)
 
   val config = ConfigFactory.load()
   val contributeUrl = config.getString("contribute.url")

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -9,7 +9,7 @@ import com.gu.i18n._
 import com.netaporter.uri.dsl._
 import configuration.Config
 import models.ContributionAmount
-import monitoring.SentryLogger
+import monitoring.TagAwareLogger
 import play.api.mvc._
 import play.filters.csrf.{CSRF, CSRFAddToken}
 import services.PaymentServices

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -9,7 +9,7 @@ import com.gu.i18n._
 import com.netaporter.uri.dsl._
 import configuration.Config
 import models.ContributionAmount
-import monitoring.SentryTagLogger
+import monitoring.SentryLogger
 import play.api.mvc._
 import play.filters.csrf.{CSRF, CSRFAddToken}
 import services.PaymentServices

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -9,6 +9,7 @@ import com.gu.i18n._
 import com.netaporter.uri.dsl._
 import configuration.Config
 import models.ContributionAmount
+import monitoring.SentryTagLogger
 import play.api.mvc._
 import play.filters.csrf.{CSRF, CSRFAddToken}
 import services.PaymentServices
@@ -52,6 +53,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken) ex
 
   def contribute(countryGroup: CountryGroup, error: Option[PaymentError] = None) = addToken {
     (NoCacheAction andThen MobileSupportAction andThen ABTestAction) { implicit request =>
+
       val errorMessage = error.map(_.message)
       val stripe = paymentServices.stripeServiceFor(request)
       val cmp = request.getQueryString("CMP")

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -16,9 +16,9 @@ import controllers.forms.ContributionRequest
 import cookies.ContribTimestampCookieAttributes
 import cookies.syntax._
 import models._
-import monitoring.SentryLoggingTags
+import monitoring.LoggingTags
 import org.joda.time.DateTime
-import monitoring.SentryLogger
+import monitoring.TagAwareLogger
 import play.api.libs.json._
 import play.api.mvc._
 import services.PaymentServices
@@ -27,7 +27,7 @@ import utils.MaxAmount
 import scala.concurrent.{ExecutionContext, Future}
 
 class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(implicit ec: ExecutionContext)
-  extends Controller with Redirect with SentryLogger {
+  extends Controller with Redirect with TagAwareLogger {
 
   // THIS ENDPOINT IS USED BY BOTH THE FRONTEND AND THE MOBILE-APP
   def pay = (NoCacheAction andThen MobileSupportAction andThen ABTestAction)
@@ -114,7 +114,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
   def hook = SharedSecretAction(webhookKey) {
     NoCacheAction.async(parse.json) { implicit request =>
 
-      def withParsedStripeHook(stripeHookJson: JsValue)(block: StripeHook => Future[Result])(implicit tags: SentryLoggingTags): Future[Result] = {
+      def withParsedStripeHook(stripeHookJson: JsValue)(block: StripeHook => Future[Result])(implicit tags: LoggingTags): Future[Result] = {
         stripeHookJson.validate[StripeHook] match {
           case JsError(err) =>
             error(s"Unable to parse the stripe hook: $err")

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import models.Autofill
+import monitoring.SentryTagLogger
 import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, Controller, Result}
 import services.IdentityService
@@ -9,13 +10,13 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class UserController(identityService: IdentityService)(implicit ec: ExecutionContext) extends Controller {
 
-  def autofill: Action[AnyContent] = Action.async { req =>
+  def autofill: Action[AnyContent] = Action.async { implicit request =>
 
     def serialise(result: Autofill): Result = {
       NoCache(Ok(Json.toJson(result)))
     }
 
-    req.cookies.get("SC_GU_U") match {
+    request.cookies.get("SC_GU_U") match {
       case Some(cookie) => identityService.autofill(cookie.value).map(serialise)
       case None => Future.successful(serialise(Autofill.empty))
     }

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import models.Autofill
-import monitoring.SentryLogger
+import monitoring.TagAwareLogger
 import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, Controller, Result}
 import services.IdentityService

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import models.Autofill
-import monitoring.SentryTagLogger
+import monitoring.SentryLogger
 import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, Controller, Result}
 import services.IdentityService

--- a/app/data/ContributionData.scala
+++ b/app/data/ContributionData.scala
@@ -7,7 +7,8 @@ import cats.data.EitherT
 import cats.syntax.either._
 import data.AnormMappings._
 import models.{ContributionMetaData, Contributor, PaymentHook}
-import play.api.Logger
+import monitoring.SentryLoggingTags
+import monitoring.{SentryTagLogger => Logger}
 import play.api.db.Database
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -15,7 +16,7 @@ import scala.util.Try
 
 class ContributionData(db: Database)(implicit ec: ExecutionContext) {
 
-  def withAsyncConnection[A](autocommit: Boolean = false)(block: Connection => A): EitherT[Future, String, A] = EitherT(Future {
+  def withAsyncConnection[A](autocommit: Boolean = false)(block: Connection => A)(implicit tags: SentryLoggingTags): EitherT[Future, String, A] = EitherT(Future {
     val result = Try(db.withConnection(autocommit)(block))
     Either.fromTry(result).leftMap { exception =>
       Logger.error("Error encountered during the execution of the sql query", exception)
@@ -23,7 +24,7 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) {
     }
   })
 
-  def insertPaymentHook(paymentHook: PaymentHook): EitherT[Future, String, PaymentHook] = {
+  def insertPaymentHook(paymentHook: PaymentHook)(implicit tags: SentryLoggingTags): EitherT[Future, String, PaymentHook] = {
     withAsyncConnection(autocommit = true) { implicit conn =>
       val request = SQL"""
         INSERT INTO payment_hooks(
@@ -62,7 +63,7 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) {
     }
   }
 
-  def insertPaymentMetaData(pmd: ContributionMetaData): EitherT[Future, String, ContributionMetaData] = {
+  def insertPaymentMetaData(pmd: ContributionMetaData)(implicit tags: SentryLoggingTags): EitherT[Future, String, ContributionMetaData] = {
     withAsyncConnection(autocommit = true) { implicit conn =>
       val request = SQL"""
         INSERT INTO contribution_metadata(
@@ -107,7 +108,7 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) {
     }
   }
 
-  def saveContributor(contributor: Contributor): EitherT[Future, String, Contributor] = {
+  def saveContributor(contributor: Contributor)(implicit tags: SentryLoggingTags): EitherT[Future, String, Contributor] = {
     withAsyncConnection(autocommit = true) { implicit conn =>
       // Note that the contributor ID will only set on insert. it's not touched on update.
       val request = SQL"""

--- a/app/data/ContributionData.scala
+++ b/app/data/ContributionData.scala
@@ -8,18 +8,18 @@ import cats.syntax.either._
 import data.AnormMappings._
 import models.{ContributionMetaData, Contributor, PaymentHook}
 import monitoring.SentryLoggingTags
-import monitoring.{SentryTagLogger => Logger}
+import monitoring.SentryLogger
 import play.api.db.Database
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-class ContributionData(db: Database)(implicit ec: ExecutionContext) {
+class ContributionData(db: Database)(implicit ec: ExecutionContext) extends SentryLogger {
 
   def withAsyncConnection[A](autocommit: Boolean = false)(block: Connection => A)(implicit tags: SentryLoggingTags): EitherT[Future, String, A] = EitherT(Future {
     val result = Try(db.withConnection(autocommit)(block))
     Either.fromTry(result).leftMap { exception =>
-      Logger.error("Error encountered during the execution of the sql query", exception)
+      error("Error encountered during the execution of the sql query", exception)
       "Error encountered during the execution of the sql query"
     }
   })

--- a/app/data/ContributionData.scala
+++ b/app/data/ContributionData.scala
@@ -7,16 +7,16 @@ import cats.data.EitherT
 import cats.syntax.either._
 import data.AnormMappings._
 import models.{ContributionMetaData, Contributor, PaymentHook}
-import monitoring.SentryLoggingTags
-import monitoring.SentryLogger
+import monitoring.LoggingTags
+import monitoring.TagAwareLogger
 import play.api.db.Database
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-class ContributionData(db: Database)(implicit ec: ExecutionContext) extends SentryLogger {
+class ContributionData(db: Database)(implicit ec: ExecutionContext) extends TagAwareLogger {
 
-  def withAsyncConnection[A](autocommit: Boolean = false)(block: Connection => A)(implicit tags: SentryLoggingTags): EitherT[Future, String, A] = EitherT(Future {
+  def withAsyncConnection[A](autocommit: Boolean = false)(block: Connection => A)(implicit tags: LoggingTags): EitherT[Future, String, A] = EitherT(Future {
     val result = Try(db.withConnection(autocommit)(block))
     Either.fromTry(result).leftMap { exception =>
       error("Error encountered during the execution of the sql query", exception)
@@ -24,7 +24,7 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) extends Sent
     }
   })
 
-  def insertPaymentHook(paymentHook: PaymentHook)(implicit tags: SentryLoggingTags): EitherT[Future, String, PaymentHook] = {
+  def insertPaymentHook(paymentHook: PaymentHook)(implicit tags: LoggingTags): EitherT[Future, String, PaymentHook] = {
     withAsyncConnection(autocommit = true) { implicit conn =>
       val request = SQL"""
         INSERT INTO payment_hooks(
@@ -63,7 +63,7 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) extends Sent
     }
   }
 
-  def insertPaymentMetaData(pmd: ContributionMetaData)(implicit tags: SentryLoggingTags): EitherT[Future, String, ContributionMetaData] = {
+  def insertPaymentMetaData(pmd: ContributionMetaData)(implicit tags: LoggingTags): EitherT[Future, String, ContributionMetaData] = {
     withAsyncConnection(autocommit = true) { implicit conn =>
       val request = SQL"""
         INSERT INTO contribution_metadata(
@@ -108,7 +108,7 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) extends Sent
     }
   }
 
-  def saveContributor(contributor: Contributor)(implicit tags: SentryLoggingTags): EitherT[Future, String, Contributor] = {
+  def saveContributor(contributor: Contributor)(implicit tags: LoggingTags): EitherT[Future, String, Contributor] = {
     withAsyncConnection(autocommit = true) { implicit conn =>
       // Note that the contributor ID will only set on insert. it's not touched on update.
       val request = SQL"""

--- a/app/monitoring/ErrorHandler.scala
+++ b/app/monitoring/ErrorHandler.scala
@@ -4,7 +4,7 @@ import javax.inject._
 
 import com.gu.identity.play.AuthenticatedIdUser
 import controllers.{Cached, NoCache}
-import monitoring.SentryLogging._
+import monitoring.SentryLoggingTags._
 import org.slf4j.MDC
 import play.api._
 import play.api.http.DefaultHttpErrorHandler
@@ -27,9 +27,9 @@ class ErrorHandler @Inject()(
 
   override def logServerError(request: RequestHeader, usefulException: UsefulException) {
     try {
-      for (identityUser <- identityAuthProvider(request)) { MDC.put(UserIdentityId, identityUser.id) }
+      for (identityUser <- identityAuthProvider(request)) MDC.put(userIdentityId, identityUser.id)
 
-      MDC.put(PlayErrorId, usefulException.id)
+      MDC.put(playErrorId, usefulException.id)
 
       super.logServerError(request, usefulException)
 

--- a/app/monitoring/ErrorHandler.scala
+++ b/app/monitoring/ErrorHandler.scala
@@ -4,7 +4,7 @@ import javax.inject._
 
 import com.gu.identity.play.AuthenticatedIdUser
 import controllers.{Cached, NoCache}
-import monitoring.SentryLoggingTags._
+import monitoring.SentryLogging._
 import org.slf4j.MDC
 import play.api._
 import play.api.http.DefaultHttpErrorHandler
@@ -27,9 +27,9 @@ class ErrorHandler @Inject()(
 
   override def logServerError(request: RequestHeader, usefulException: UsefulException) {
     try {
-      for (identityUser <- identityAuthProvider(request)) MDC.put(userIdentityId, identityUser.id)
+      for (identityUser <- identityAuthProvider(request)) MDC.put(UserIdentityId, identityUser.id)
 
-      MDC.put(playErrorId, usefulException.id)
+      MDC.put(PlayErrorId, usefulException.id)
 
       super.logServerError(request, usefulException)
 

--- a/app/monitoring/LoggingTags.scala
+++ b/app/monitoring/LoggingTags.scala
@@ -1,0 +1,56 @@
+package monitoring
+
+import java.util.UUID
+
+import com.typesafe.scalalogging.LazyLogging
+import org.slf4j.MDC
+import play.api.mvc.Request
+
+// Tags to be included in a log statement using Mapped Diagnostic Context (MDC).
+// A MDC can be used to supplement log messages with additional contextual information,
+// or provide tags to a Sentry Appender.
+//
+// References:
+// - https://logback.qos.ch/manual/mdc.html, and
+// - https://github.com/getsentry/raven-java/blob/master/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
+case class LoggingTags(browserId: String, requestId: UUID) {
+
+  def toMap: Map[String, String] = Map(
+    LoggingTags.browserId -> browserId,
+    LoggingTags.requestId -> requestId.toString
+  )
+}
+
+object LoggingTags {
+
+  val browserId = "browserId"
+  val requestId = "requestId"
+
+  val allTags = Seq(browserId, requestId)
+
+  // Means that if `implicit request =>` is used in an Action, an implicit SentryLoggingTags instance will be in scope.
+  implicit def fromRequest(implicit request: Request[Any]): LoggingTags = {
+    val browserId = request.cookies.get("bwid").map(_.value).getOrElse("unknown")
+    LoggingTags(browserId, UUID.randomUUID)
+  }
+}
+
+trait TagAwareLogger extends LazyLogging {
+
+  private[this] def withTags(loggingExpr: => Unit)(implicit tags: LoggingTags): Unit =
+    try {
+      for ((tagName, tagValue) <- tags.toMap) MDC.put(tagName, tagValue)
+      loggingExpr
+    } finally {
+      MDC.clear()
+    }
+
+  def info(msg: String)(implicit tags: LoggingTags): Unit =
+    withTags(logger.info(msg))
+
+  def error(msg: String, t: Throwable)(implicit tags: LoggingTags): Unit =
+    withTags(logger.error(msg, t))
+
+  def error(msg: String)(implicit tags: LoggingTags): Unit =
+    withTags(logger.error(msg))
+}

--- a/app/monitoring/LoggingTags.scala
+++ b/app/monitoring/LoggingTags.scala
@@ -28,7 +28,7 @@ object LoggingTags {
 
   val allTags = Seq(browserId, requestId)
 
-  // Means that if `implicit request =>` is used in an Action, an implicit SentryLoggingTags instance will be in scope.
+  // Means that if `implicit request =>` is used in an Action, an implicit LoggingTags instance will be in scope.
   implicit def fromRequest(implicit request: Request[Any]): LoggingTags = {
     val browserId = request.cookies.get("bwid").map(_.value).getOrElse("unknown")
     LoggingTags(browserId, UUID.randomUUID)

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -10,7 +10,8 @@ import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import com.amazonaws.services.sqs.model._
 import configuration.Config
 import models.ContributorRow
-import play.api.Logger
+import monitoring.SentryLoggingTags
+import monitoring.{SentryTagLogger => Logger}
 import play.api.libs.json._
 import utils.AwsAsyncHandler
 
@@ -34,7 +35,7 @@ class EmailService(implicit ec: ExecutionContext) extends LazyLogging {
   // We don't want to send them an automatic email yet
   val noEmailCampaignCodes = Set("co_uk_ema_cns_a", "co_uk_ema_cns_b", "co_us_ema_cnsus_a", "co_int_email_patronask")
 
-  def thank(row: ContributorRow): EitherT[Future, Throwable, SendMessageResult] = {
+  def thank(row: ContributorRow)(implicit tags: SentryLoggingTags): EitherT[Future, Throwable, SendMessageResult] = {
     if (noEmailCampaignCodes.exists(row.cmp.contains)) {
       EitherT.pure[Future, Throwable, SendMessageResult](new SendMessageResult)
     } else {
@@ -42,7 +43,7 @@ class EmailService(implicit ec: ExecutionContext) extends LazyLogging {
     }
   }
 
-  def sendEmailToQueue(queueUrl: String, row: ContributorRow): EitherT[Future, Throwable, SendMessageResult] = {
+  def sendEmailToQueue(queueUrl: String, row: ContributorRow)(implicit tags: SentryLoggingTags): EitherT[Future, Throwable, SendMessageResult] = {
     val payload = Json.stringify(Json.toJson(row))
 
     val handler = new AwsAsyncHandler[SendMessageRequest, SendMessageResult]

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -10,14 +10,14 @@ import com.amazonaws.services.sqs.AmazonSQSAsyncClient
 import com.amazonaws.services.sqs.model._
 import configuration.Config
 import models.ContributorRow
-import monitoring.SentryLoggingTags
-import monitoring.SentryLogger
+import monitoring.LoggingTags
+import monitoring.TagAwareLogger
 import play.api.libs.json._
 import utils.AwsAsyncHandler
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class EmailService(implicit ec: ExecutionContext) extends SentryLogger {
+class EmailService(implicit ec: ExecutionContext) extends TagAwareLogger {
 
   val credentialsProviderChain: AWSCredentialsProviderChain = new AWSCredentialsProviderChain(
     new EnvironmentVariableCredentialsProvider,
@@ -35,7 +35,7 @@ class EmailService(implicit ec: ExecutionContext) extends SentryLogger {
   // We don't want to send them an automatic email yet
   val noEmailCampaignCodes = Set("co_uk_ema_cns_a", "co_uk_ema_cns_b", "co_us_ema_cnsus_a", "co_int_email_patronask")
 
-  def thank(row: ContributorRow)(implicit tags: SentryLoggingTags): EitherT[Future, Throwable, SendMessageResult] = {
+  def thank(row: ContributorRow)(implicit tags: LoggingTags): EitherT[Future, Throwable, SendMessageResult] = {
     if (noEmailCampaignCodes.exists(row.cmp.contains)) {
       EitherT.pure[Future, Throwable, SendMessageResult](new SendMessageResult)
     } else {
@@ -43,7 +43,7 @@ class EmailService(implicit ec: ExecutionContext) extends SentryLogger {
     }
   }
 
-  def sendEmailToQueue(queueUrl: String, row: ContributorRow)(implicit tags: SentryLoggingTags): EitherT[Future, Throwable, SendMessageResult] = {
+  def sendEmailToQueue(queueUrl: String, row: ContributorRow)(implicit tags: LoggingTags): EitherT[Future, Throwable, SendMessageResult] = {
     val payload = Json.stringify(Json.toJson(row))
 
     val handler = new AwsAsyncHandler[SendMessageRequest, SendMessageResult]

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -11,13 +11,13 @@ import com.amazonaws.services.sqs.model._
 import configuration.Config
 import models.ContributorRow
 import monitoring.SentryLoggingTags
-import monitoring.{SentryTagLogger => Logger}
+import monitoring.SentryLogger
 import play.api.libs.json._
 import utils.AwsAsyncHandler
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class EmailService(implicit ec: ExecutionContext) extends LazyLogging {
+class EmailService(implicit ec: ExecutionContext) extends SentryLogger {
 
   val credentialsProviderChain: AWSCredentialsProviderChain = new AWSCredentialsProviderChain(
     new EnvironmentVariableCredentialsProvider,
@@ -53,7 +53,7 @@ class EmailService(implicit ec: ExecutionContext) extends LazyLogging {
       Right(result)
     } recover {
       case t: Throwable =>
-        Logger.error(s"Unable to send message to the SQS queue $queueUrl", t)
+        error(s"Unable to send message to the SQS queue $queueUrl", t)
         Left(t)
     })
   }

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -14,8 +14,8 @@ import com.paypal.base.rest.APIContext
 import com.typesafe.config.Config
 import data.ContributionData
 import models._
-import monitoring.SentryLogger
-import monitoring.SentryLoggingTags
+import monitoring.TagAwareLogger
+import monitoring.LoggingTags
 import org.joda.time.DateTime
 import play.api.libs.json.Json
 
@@ -49,13 +49,13 @@ class PaypalService(
   contributionData: ContributionData,
   identityService: IdentityService,
   emailService: EmailService
-)(implicit ec: ExecutionContext) extends SentryLogger {
+)(implicit ec: ExecutionContext) extends TagAwareLogger {
   val description = "Contribution to the guardian"
   val credentials = config.credentials
 
   def apiContext: APIContext = new APIContext(credentials.clientId, credentials.clientSecret, config.paypalMode)
 
-  private def asyncExecute[A](block: => A)(implicit tags: SentryLoggingTags): EitherT[Future, String, A] = EitherT(Future {
+  private def asyncExecute[A](block: => A)(implicit tags: LoggingTags): EitherT[Future, String, A] = EitherT(Future {
     val result = Try(block)
     Either.fromTry(result).leftMap { exception =>
       error("Error while calling PayPal API", exception)
@@ -82,7 +82,7 @@ class PaypalService(
     refererUrl: Option[String],
     ophanPageviewId: Option[String],
     ophanBrowserId: Option[String]
-  )(implicit tags: SentryLoggingTags): EitherT[Future, String, Uri] = {
+  )(implicit tags: LoggingTags): EitherT[Future, String, Uri] = {
 
     val paymentToCreate = {
 
@@ -139,7 +139,7 @@ class PaypalService(
       }
   }
 
-  def executePayment(paymentId: String, payerId: String)(implicit tags: SentryLoggingTags): EitherT[Future, String, Payment] = {
+  def executePayment(paymentId: String, payerId: String)(implicit tags: LoggingTags): EitherT[Future, String, Payment] = {
     val payment = new Payment().setId(paymentId)
     val paymentExecution = new PaymentExecution().setPayerId(payerId)
     asyncExecute(payment.execute(apiContext, paymentExecution)) transform  {
@@ -160,7 +160,7 @@ class PaypalService(
     ophanPageviewId: Option[String],
     ophanBrowserId: Option[String],
     idUser: Option[IdentityId]
-  )(implicit tags: SentryLoggingTags): EitherT[Future, String, SavedContributionData] = {
+  )(implicit tags: LoggingTags): EitherT[Future, String, SavedContributionData] = {
 
     def tryToEitherT[A](block: => A): EitherT[Future, String, A] = {
       EitherT.fromEither[Future](Either.catchNonFatal(block).leftMap { t: Throwable =>
@@ -241,7 +241,7 @@ class PaypalService(
     )
   }
 
-  def updateMarketingOptIn(email: String, marketingOptInt: Boolean, idUser: Option[IdentityId])(implicit tags: SentryLoggingTags): EitherT[Future, String, Contributor] = {
+  def updateMarketingOptIn(email: String, marketingOptInt: Boolean, idUser: Option[IdentityId])(implicit tags: LoggingTags): EitherT[Future, String, Contributor] = {
     val contributor = Contributor(
       email = email,
       contributorId = None,
@@ -266,7 +266,7 @@ class PaypalService(
     Event.validateReceivedEvent(context, headers.asJava, body)
   }
 
-  def processPaymentHook(paypalHook: PaypalHook)(implicit tags: SentryLoggingTags): EitherT[Future, String, PaymentHook] = {
+  def processPaymentHook(paypalHook: PaypalHook)(implicit tags: LoggingTags): EitherT[Future, String, PaymentHook] = {
     contributionData.insertPaymentHook(PaymentHook.fromPaypal(paypalHook))
   }
 

--- a/app/services/StripeService.scala
+++ b/app/services/StripeService.scala
@@ -9,8 +9,8 @@ import models._
 import cats.implicits._
 import com.gu.okhttp.RequestRunners
 import com.gu.stripe.Stripe.{Charge, Event}
-import monitoring.SentryLoggingTags
-import monitoring.SentryLogger
+import monitoring.LoggingTags
+import monitoring.TagAwareLogger
 import org.joda.time.DateTime
 import play.api.libs.json.Json
 
@@ -40,7 +40,7 @@ class StripeService(
     ophanPageviewId: String,
     ophanBrowserId: Option[String],
     idUser: Option[IdentityId]
-  )(implicit tags: SentryLoggingTags): EitherT[Future, String, SavedContributionData] = {
+  )(implicit tags: LoggingTags): EitherT[Future, String, SavedContributionData] = {
 
     // Fire and forget: we don't want to stop the user flow
     idUser.map { id =>
@@ -88,7 +88,7 @@ class StripeService(
     )
   }
 
-  def processPaymentHook(stripeHook: StripeHook)(implicit tags: SentryLoggingTags): EitherT[Future, String, PaymentHook] = {
+  def processPaymentHook(stripeHook: StripeHook)(implicit tags: LoggingTags): EitherT[Future, String, PaymentHook] = {
 
     def convertedAmount(event: Event[Charge]): OptionT[Future, BigDecimal] = {
       for {

--- a/app/services/StripeService.scala
+++ b/app/services/StripeService.scala
@@ -10,7 +10,7 @@ import cats.implicits._
 import com.gu.okhttp.RequestRunners
 import com.gu.stripe.Stripe.{Charge, Event}
 import monitoring.SentryLoggingTags
-import monitoring.SentryTagLogger
+import monitoring.SentryLogger
 import org.joda.time.DateTime
 import play.api.libs.json.Json
 

--- a/app/services/StripeService.scala
+++ b/app/services/StripeService.scala
@@ -9,6 +9,8 @@ import models._
 import cats.implicits._
 import com.gu.okhttp.RequestRunners
 import com.gu.stripe.Stripe.{Charge, Event}
+import monitoring.SentryLoggingTags
+import monitoring.SentryTagLogger
 import org.joda.time.DateTime
 import play.api.libs.json.Json
 
@@ -38,7 +40,7 @@ class StripeService(
     ophanPageviewId: String,
     ophanBrowserId: Option[String],
     idUser: Option[IdentityId]
-  ): EitherT[Future, String, SavedContributionData] = {
+  )(implicit tags: SentryLoggingTags): EitherT[Future, String, SavedContributionData] = {
 
     // Fire and forget: we don't want to stop the user flow
     idUser.map { id =>
@@ -86,7 +88,7 @@ class StripeService(
     )
   }
 
-  def processPaymentHook(stripeHook: StripeHook): EitherT[Future, String, PaymentHook] = {
+  def processPaymentHook(stripeHook: StripeHook)(implicit tags: SentryLoggingTags): EitherT[Future, String, PaymentHook] = {
 
     def convertedAmount(event: Event[Charge]): OptionT[Future, BigDecimal] = {
       for {


### PR DESCRIPTION
cc @guardian/contributions 

This pull request attempts to lay the groundwork for tagging log requests.

Log entries are currently tagged with `browser id` and `request id`.

When a request is made, an implicit `LoggingTags` instance is created and this is passed recursively to any functions which rely on this information for logging. 

Under-the-hood the [Mapped Diagnostic Context](https://logback.qos.ch/manual/mdc.html) which stores contextual data on a per-thread basis is updated and this is queried when the log call is made.

__Primary use case__: the [logback Sentry Appender](https://github.com/getsentry/raven-java/blob/master/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java) queries the MDC to add tags before sending the data to Sentry. This will allow us to filter logs in Sentry by browser id or request id; or whatever tags we choose to add in the future.

__Secondary use case__ (not yet implemented): the log entries that are written to `logs/application.log` can be formatted to include this additional contextual information e.g. [Example 7.1](https://logback.qos.ch/manual/mdc.html)