### PR TITLE
Configure Prout to add Sentry Releases

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -4,5 +4,8 @@
             "url": "https://contribute.theguardian.com/uk",
             "overdue": "14M"
         }
+    },
+    "sentry": {
+        "projects": ["contributions", "contributions-js"]
     }
 }


### PR DESCRIPTION
Sentry recently released some [interesting functionality around tracking issues related to specific code-changes](https://blog.sentry.io/2017/05/01/release-commits.html), and Prout now has some basic support for this, tracked in https://github.com/guardian/prout/issues/47.

![image](https://docs.sentry.io/_images/releases-overview.png)

To activate Prout's support, you just need to ensure Sentry has 'connected' to your GitHub repo in https://sentry.io/organizations/the-guardian/repos/, and then add a stanza like this to your `.prout.json`:

```
"sentry": {
  "projects": ["contributions", "contributions-js"]
}
```

...those project slugs correspond to the Sentry projects used with this stack:

* https://sentry.io/the-guardian/contributions/
* https://sentry.io/the-guardian/contributions-js/
