### PR TITLE
logging tags re-implemented to facilitate adding new tags

### DIFF
--- a/app/monitoring/LoggingTags.scala
+++ b/app/monitoring/LoggingTags.scala
@@ -1,7 +1,5 @@
 package monitoring
 
-import java.util.UUID
-
 import com.typesafe.scalalogging.LazyLogging
 import org.slf4j.MDC
 import play.api.mvc.RequestHeader
@@ -34,7 +32,7 @@ object LoggingTag extends enumeratum.Enum[LoggingTag] {
 
   case object RequestId extends LoggingTag {
     override def value(header: RequestHeader): String =
-      UUID.randomUUID().toString
+      header.id.toString
   }
 }
 

--- a/app/monitoring/LoggingTags.scala
+++ b/app/monitoring/LoggingTags.scala
@@ -4,42 +4,59 @@ import java.util.UUID
 
 import com.typesafe.scalalogging.LazyLogging
 import org.slf4j.MDC
-import play.api.mvc.Request
+import play.api.mvc.RequestHeader
 
 // Tags to be included in a log statement using Mapped Diagnostic Context (MDC).
-// A MDC can be used to supplement log messages with additional contextual information,
+// A MDC can be used to e.g. supplement log messages with additional contextual information,
 // or provide tags to a Sentry Appender.
 //
 // References:
-// - https://logback.qos.ch/manual/mdc.html, and
+// - https://logback.qos.ch/manual/mdc.html
 // - https://github.com/getsentry/raven-java/blob/master/raven-logback/src/main/java/com/getsentry/raven/logback/SentryAppender.java
-case class LoggingTags(browserId: String, requestId: UUID) {
+sealed trait LoggingTag extends enumeratum.EnumEntry { self =>
 
-  def toMap: Map[String, String] = Map(
-    LoggingTags.browserId -> browserId,
-    LoggingTags.requestId -> requestId.toString
-  )
+  def name: String = self.entryName
+
+  // The value of each tag should be able to be derived from a request header.
+  def value(header: RequestHeader): String
 }
+
+object LoggingTag extends enumeratum.Enum[LoggingTag] {
+
+  override def values: Seq[LoggingTag] = findValues
+
+  def names: Seq[String] = values.map(_.name)
+
+  case object BrowserId extends LoggingTag {
+    override def value(header: RequestHeader): String =
+      header.cookies.get("bwid").map(_.value).getOrElse("unknown")
+  }
+
+  case object RequestId extends LoggingTag {
+    override def value(header: RequestHeader): String =
+      UUID.randomUUID().toString
+  }
+}
+
+// Constructor private as a LoggingTags instance should only ever be created from the fromRequestHeader() method.
+case class LoggingTags private (tags: Map[TagKey, TagValue])
 
 object LoggingTags {
 
-  val browserId = "browserId"
-  val requestId = "requestId"
-
-  val allTags = Seq(browserId, requestId)
-
   // Means that if `implicit request =>` is used in an Action, an implicit LoggingTags instance will be in scope.
-  implicit def fromRequest(implicit request: Request[Any]): LoggingTags = {
-    val browserId = request.cookies.get("bwid").map(_.value).getOrElse("unknown")
-    LoggingTags(browserId, UUID.randomUUID)
-  }
+  implicit def fromRequestHeader(implicit header: RequestHeader): LoggingTags =
+    LoggingTags {
+      LoggingTag.values.foldLeft(Map.empty[TagKey, TagValue]) {
+        case (tags, tag) => tags + (tag.name -> tag.value(header))
+      }
+    }
 }
 
 trait TagAwareLogger extends LazyLogging {
 
   private[this] def withTags(loggingExpr: => Unit)(implicit tags: LoggingTags): Unit =
     try {
-      for ((tagName, tagValue) <- tags.toMap) MDC.put(tagName, tagValue)
+      for ((tagName, tagValue) <- tags.tags) MDC.put(tagName, tagValue)
       loggingExpr
     } finally {
       MDC.clear()

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -38,7 +38,7 @@ object SentryLogging extends LazyLogging {
           addFilter(filter)
           setTags(tagsString)
           setRelease(app.BuildInfo.gitCommitId)
-          setExtraTags((AllMDCTags ++ LoggingTags.allTags).mkString(","))
+          setExtraTags((AllMDCTags ++ LoggingTag.names).mkString(","))
           setContext(LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext])
         }
         sentryAppender.start()

--- a/app/monitoring/package.scala
+++ b/app/monitoring/package.scala
@@ -1,0 +1,4 @@
+package object monitoring {
+  private[monitoring] type TagKey = String
+  private[monitoring] type TagValue = String
+}


### PR DESCRIPTION
cc @guardian/contributions 

This pull request enumerates the different logging tags, using the `enumeratum` library to do so.

This facilitates adding new tags without having to edit existing code (c.f. next pull request where new tags will be added).


