### PR TITLE
Default error handling updated

### DIFF
--- a/app/monitoring/LoggingTags.scala
+++ b/app/monitoring/LoggingTags.scala
@@ -31,8 +31,11 @@ object LoggingTag extends enumeratum.Enum[LoggingTag] {
   }
 
   case object RequestId extends LoggingTag {
-    override def value(header: RequestHeader): String =
-      header.id.toString
+    override def value(header: RequestHeader): String = header.id.toString
+  }
+
+  case object Path extends LoggingTag {
+    override def value(header: RequestHeader): String = header.path
   }
 }
 


### PR DESCRIPTION
cc @guardian/contributions 

The most common error reported in the Sentry project `Membership / Contributions` is a bad request from the client. However, currently no additional information is logged by the application.

This pull request:
- adds the path of a request as a logging tag
- logs more details about a bad request - the error message generated by Play, plus the logging tags (inferred from the request header)