### PR TITLE
update the error messages related to the identity API

### DIFF
--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -4,7 +4,9 @@ import com.typesafe.config.Config
 import models.{Autofill, IdentityId}
 import monitoring.LoggingTags
 import monitoring.TagAwareLogger
+import play.api.http.Status
 import play.api.libs.json._
+import play.api.libs.ws.WSResponse
 import play.api.libs.ws.{WSClient, WSRequest}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -29,49 +31,41 @@ class IdentityService(wsClient: WSClient, config: Config)(implicit ec: Execution
     }
   }
 
-  def autofill(cookie: String)(implicit tags: LoggingTags): Future[Autofill] = {
-
-    def name(optionalFirstName: Option[String], optionalSecondName: Option[String]): Option[String] = for {
-      firstName <- optionalFirstName
-      secondName <- optionalSecondName
+  def concatNames(first: Option[String], second: Option[String]): Option[String] =
+    for {
+      firstName <- first
+      secondName <- second
     } yield s"$firstName $secondName"
 
-    def parse(jsValue: JsValue)(implicit tags: LoggingTags): Autofill = {
-      val result = for {
-        status <- (jsValue \ "status").validate[String]
-        user <- (jsValue \ "user").validate[JsValue]
-        email <- (user \ "primaryEmailAddress").validateOpt[String]
-        firstName <- (user \ "privateFields" \ "firstName").validateOpt[String]
-        secondName <- (user \ "privateFields" \ "secondName").validateOpt[String]
-      } yield {
-        if (status == "ok") {
-          Autofill(name(firstName, secondName), email)
-        } else {
-          error(s"Invalid identity API response status: $status")
-          Autofill.empty
-        }
-      }
-      result match {
-        case JsSuccess(autofill, _) => autofill
-        case JsError(e) =>
-          error(s"Unable to parse json from identity $e")
-          Autofill.empty
-      }
-    }
-
-    readUser(cookie).map(parse)
-  }
-
-
-  def readUser(cookie: String)(implicit tags: LoggingTags): Future[JsValue] = {
+  def makeUserRequest(cookie: String)(implicit tags: LoggingTags): Future[WSResponse] =
     request("user/me")
       .withHeaders("X-GU-ID-FOWARDED-SC-GU-U" -> cookie)
       .withHeaders("X-GU-ID-Client-Access-Token" -> s"Bearer $token")
       .get()
-      .map(_.json)
-      .recover { case e: Exception =>
-        error("Unable to fetch user from identity", e)
-        JsObject(Seq.empty)
+
+  def parseUserResponse(json: JsValue)(implicit tags: LoggingTags): Autofill =
+    (for {
+      user <- (json \ "user").validate[JsValue]
+      email <- (user \ "primaryEmailAddress").validateOpt[String]
+      firstName <- (user \ "privateFields" \ "firstName").validateOpt[String]
+      secondName <- (user \ "privateFields" \ "secondName").validateOpt[String]
+    } yield Autofill(concatNames(firstName, secondName), email)).getOrElse {
+      error(s"Unable to parse json returned from Identity API to an autofill instance: ${Json.stringify(json)}")
+      Autofill.empty
+    }
+
+  def autofill(cookie: String)(implicit tags: LoggingTags): Future[Autofill] =
+    makeUserRequest(cookie)
+      .map {
+        case response if response.status == Status.OK =>
+          parseUserResponse(response.json)
+        case response =>
+          error(s"Status ${response.status} returned from Identity API when getting user information")
+          Autofill.empty
       }
-  }
+      .recover {
+        case err =>
+          error("Error accessing Identity API", err)
+          Autofill.empty
+      }
 }

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -50,7 +50,7 @@ class IdentityService(wsClient: WSClient, config: Config)(implicit ec: Execution
       firstName <- (user \ "privateFields" \ "firstName").validateOpt[String]
       secondName <- (user \ "privateFields" \ "secondName").validateOpt[String]
     } yield Autofill(concatNames(firstName, secondName), email)).getOrElse {
-      error(s"Unable to parse json returned from Identity API to an autofill instance: ${Json.stringify(json)}")
+      error(s"Unable to parse json returned from Identity API to an autofill instance")
       Autofill.empty
     }
 


### PR DESCRIPTION
cc @guardian/contributions 

One of the most common contribution front-end errors we get in Sentry is:

```
Unable to parse json from identity List((,List(ValidationError(List('use..
```

This pull request attempts to improve the logging around interaction with the Identity API.