### PR TITLE
Set fixed width on .l-constrained

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -35,15 +35,13 @@ $gs-max-columns: 16;
 
 @mixin constrain-layout($offset: $gs-gutter * 2) {
     margin: 0 auto;
+    width: 100%;
 
-    @include mq($until:tablet){
-        width: 100%;
-    }
     @include mq(desktop) {
-        max-width: map-get($max-widths, max-desktop) + $offset;
+        width: map-get($max-widths, max-desktop) + $offset;
     }
     @include mq(mem-full) {
-        max-width: map-get($max-widths, max-mem-full) + $offset;
+        width: map-get($max-widths, max-mem-full) + $offset;
     }
 }
 

--- a/assets/stylesheets/components/_giraffe-header.scss
+++ b/assets/stylesheets/components/_giraffe-header.scss
@@ -115,6 +115,5 @@
 
     .global-navigation__scroll {
         background: #00456e;
-        width: 100%;
     }
 }


### PR DESCRIPTION
Have split this one out from #273 

Switches from using `max-width` to `width` in the `.l-constrained` style - some containers were only hitting their max width because of the amount of content. Can't think of any reason they shouldn't be fixed width so I changed it and have checked at all breakpoints for homepage & thank you page.

I had to create an artificial example to show the problem but this change will be necessary when I remove the testimonials from the thank you page

# before
![screencapture-contribute-theguardian-uk-1495538235069](https://cloud.githubusercontent.com/assets/5122968/26352092/272af75e-3fb2-11e7-9e3a-43f9cc49743b.png)

# after
![screencapture-localhost-9111-eu-1495538228593](https://cloud.githubusercontent.com/assets/5122968/26352099/2d7fc846-3fb2-11e7-8623-affed7ac1e4a.png)


