### PR TITLE
Hard coding routes for better route parsing

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -26,7 +26,10 @@ POST           /stripe/hook                     controllers.StripeController.hoo
 GET            /ca                              controllers.Contributions.redirectToUk
 GET            /nz                              controllers.Contributions.redirectToUk
 GET            /int                             controllers.Contributions.redirectToUk
-GET            /:countryGroup                   controllers.Contributions.contribute(countryGroup: CountryGroup, error_code: Option[PaymentError]?=None)
+GET            /uk                              controllers.Contributions.contribute(countryGroup: CountryGroup?=CountryGroup.UK, error_code: Option[PaymentError]?=None)
+GET            /au                              controllers.Contributions.contribute(countryGroup: CountryGroup?=CountryGroup.Australia, error_code: Option[PaymentError]?=None)
+GET            /us                              controllers.Contributions.contribute(countryGroup: CountryGroup?=CountryGroup.US, error_code: Option[PaymentError]?=None)
+GET            /eu                              controllers.Contributions.contribute(countryGroup: CountryGroup?=CountryGroup.Europe, error_code: Option[PaymentError]?=None)
 
 GET            /:countryGroup/thank-you         controllers.Contributions.thanks(countryGroup: CountryGroup)
 GET            /:countryGroup/post-payment      controllers.Contributions.postPayment(countryGroup: CountryGroup)


### PR DESCRIPTION
Currently urls that would normally cause 404's are being caught by `/:countryGroup` generic route, and throwing a parse error instead.
This is causing noise in our logs.
<img width="830" alt="screen_shot_2017-05-24_at_09_49_43_new" src="https://cloud.githubusercontent.com/assets/1289259/26395134/15aa1c52-4067-11e7-96c1-216c8da00886.png">
This PR adds specific routes for each region, rather that having a generic route.






Have you gone through the contributions flow for all test variants ? Yep!

