### PR TITLE
Hash browser

### DIFF
--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -12,6 +12,7 @@ import com.paypal.api.payments.Payment
 import models._
 import monitoring.TagAwareLogger
 import monitoring.LoggingTags
+import monitoring.LoggingTagsProvider
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.PaymentServices
@@ -29,7 +30,7 @@ import utils.StoreMetaDataError
 import scala.concurrent.{ExecutionContext, Future}
 
 class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToken: CSRFCheck)(implicit ec: ExecutionContext)
-  extends Controller with Redirect with TagAwareLogger {
+  extends Controller with Redirect with TagAwareLogger with LoggingTagsProvider {
   import ContribTimestampCookieAttributes._
 
   def executePayment(
@@ -164,7 +165,7 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
     val paypalService = paymentServices.paypalServiceFor(request)
     val validHook = paypalService.validateEvent(request.headers.toSimpleMap, bodyText)
 
-    def withParsedPaypalHook(paypalHookJson: JsValue)(block: PaypalHook => Future[Result])(implicit tags: LoggingTags): Future[Result] = {
+    def withParsedPaypalHook(paypalHookJson: JsValue)(block: PaypalHook => Future[Result]): Future[Result] = {
       bodyJson.validate[PaypalHook] match {
         case JsSuccess(paypalHook, _) if validHook =>
           info(s"Received paymentHook: ${paypalHook.paymentId}")

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -17,6 +17,7 @@ import cookies.ContribTimestampCookieAttributes
 import cookies.syntax._
 import models._
 import monitoring.LoggingTags
+import monitoring.LoggingTagsProvider
 import org.joda.time.DateTime
 import monitoring.TagAwareLogger
 import play.api.libs.json._
@@ -27,7 +28,7 @@ import utils.MaxAmount
 import scala.concurrent.{ExecutionContext, Future}
 
 class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(implicit ec: ExecutionContext)
-  extends Controller with Redirect with TagAwareLogger {
+  extends Controller with Redirect with TagAwareLogger with LoggingTagsProvider {
 
   // THIS ENDPOINT IS USED BY BOTH THE FRONTEND AND THE MOBILE-APP
   def pay = (NoCacheAction andThen MobileSupportAction andThen ABTestAction)
@@ -114,7 +115,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
   def hook = SharedSecretAction(webhookKey) {
     NoCacheAction.async(parse.json) { implicit request =>
 
-      def withParsedStripeHook(stripeHookJson: JsValue)(block: StripeHook => Future[Result])(implicit tags: LoggingTags): Future[Result] = {
+      def withParsedStripeHook(stripeHookJson: JsValue)(block: StripeHook => Future[Result]): Future[Result] = {
         stripeHookJson.validate[StripeHook] match {
           case JsError(err) =>
             error(s"Unable to parse the stripe hook: $err")

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import models.Autofill
+import monitoring.LoggingTagsProvider
 import monitoring.TagAwareLogger
 import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, Controller, Result}
@@ -8,7 +9,8 @@ import services.IdentityService
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class UserController(identityService: IdentityService)(implicit ec: ExecutionContext) extends Controller {
+class UserController(identityService: IdentityService)(implicit ec: ExecutionContext)
+  extends Controller with LoggingTagsProvider {
 
   def autofill: Action[AnyContent] = Action.async { implicit request =>
 

--- a/app/monitoring/ErrorHandler.scala
+++ b/app/monitoring/ErrorHandler.scala
@@ -23,7 +23,7 @@ class ErrorHandler @Inject()(
     config: Configuration,
     sourceMapper: Option[SourceMapper],
     router: => Option[Router]
-) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) with TagAwareLogger {
+) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) with TagAwareLogger with LoggingTagsProvider {
 
   override def logServerError(request: RequestHeader, usefulException: UsefulException) {
     try {
@@ -47,9 +47,9 @@ class ErrorHandler @Inject()(
   override protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] =
     Future.successful(NoCache(InternalServerError(views.html.error500(exception))))
 
-  override protected def onBadRequest(request: RequestHeader, message: String): Future[Result] = {
+  override protected def onBadRequest(header: RequestHeader, message: String): Future[Result] = {
     // Implicit logging tags passed explicitly as it can not be derived implicitly (the request is not implicit).
-    error(s"Bad request: $message")(LoggingTags.fromRequestHeader(request))
-    Future.successful(NoCache(BadRequest(views.html.error400(request,message))))
+    error(s"Bad request: $message")(loggingTagsFromRequestHeader(header))
+    Future.successful(NoCache(BadRequest(views.html.error400(header, message))))
   }
 }

--- a/app/monitoring/LoggingTags.scala
+++ b/app/monitoring/LoggingTags.scala
@@ -58,7 +58,7 @@ case class LoggingTags private (tags: Map[TagKey, TagValue])
 trait LoggingTagsProvider {
 
   // InfoSec have said it is ok to use the SHA-256 algorithm for hashing sensitive data.
-  private val hasher: Hasher = SHA256Hasher.instance
+  private val hasher: Hasher = SHA256Hasher
 
   implicit def loggingTagsFromRequestHeader(implicit header: RequestHeader): LoggingTags =
     LoggingTags {

--- a/app/monitoring/LoggingTags.scala
+++ b/app/monitoring/LoggingTags.scala
@@ -3,6 +3,8 @@ package monitoring
 import com.typesafe.scalalogging.LazyLogging
 import org.slf4j.MDC
 import play.api.mvc.RequestHeader
+import utils.Hasher
+import utils.SHA256Hasher
 
 // Tags to be included in a log statement using Mapped Diagnostic Context (MDC).
 // A MDC can be used to e.g. supplement log messages with additional contextual information,
@@ -15,8 +17,12 @@ sealed trait LoggingTag extends enumeratum.EnumEntry { self =>
 
   def name: String = self.entryName
 
-  // The value of each tag should be able to be derived from a request header.
-  def value(header: RequestHeader): String
+  def hashValue: Boolean
+
+  def value(header: RequestHeader): Option[String]
+
+  def loggingValue(header: RequestHeader, hasher: Hasher): String =
+    value(header).map { tagValue => if (hashValue) hasher.hash(tagValue) else tagValue }.getOrElse("unknown")
 }
 
 object LoggingTag extends enumeratum.Enum[LoggingTag] {
@@ -26,29 +32,38 @@ object LoggingTag extends enumeratum.Enum[LoggingTag] {
   def names: Seq[String] = values.map(_.name)
 
   case object BrowserId extends LoggingTag {
-    override def value(header: RequestHeader): String =
-      header.cookies.get("bwid").map(_.value).getOrElse("unknown")
+    override val hashValue: Boolean = true
+    override def value(header: RequestHeader): Option[String] =
+      header.cookies.get("bwid").map(_.value)
   }
 
   case object RequestId extends LoggingTag {
-    override def value(header: RequestHeader): String = header.id.toString
+    override val hashValue: Boolean = false
+    override def value(header: RequestHeader): Option[String] = Some(header.id.toString)
   }
 
   case object Path extends LoggingTag {
-    override def value(header: RequestHeader): String = header.path
+    override val hashValue: Boolean = false
+    override def value(header: RequestHeader): Option[String] = Some(header.path)
   }
 }
 
 // Constructor private as a LoggingTags instance should only ever be created from the fromRequestHeader() method.
 case class LoggingTags private (tags: Map[TagKey, TagValue])
 
-object LoggingTags {
+// Mixing this into a controller means that when `implicit request =>` is used in an Action,
+// an implicit LoggingTags instance for the request will be in scope.
+// This logic could be handled in the LoggingTags companion object,
+// but it's maybe better to require an explicit mixin to get this implicit behaviour (?)
+trait LoggingTagsProvider {
 
-  // Means that if `implicit request =>` is used in an Action, an implicit LoggingTags instance will be in scope.
-  implicit def fromRequestHeader(implicit header: RequestHeader): LoggingTags =
+  // InfoSec have said it is ok to use the SHA-256 algorithm for hashing sensitive data.
+  private val hasher: Hasher = SHA256Hasher.instance
+
+  implicit def loggingTagsFromRequestHeader(implicit header: RequestHeader): LoggingTags =
     LoggingTags {
       LoggingTag.values.foldLeft(Map.empty[TagKey, TagValue]) {
-        case (tags, tag) => tags + (tag.name -> tag.value(header))
+        case (tags, tag) => tags + (tag.name -> tag.loggingValue(header, hasher))
       }
     }
 }

--- a/app/utils/Hasher.scala
+++ b/app/utils/Hasher.scala
@@ -1,8 +1,9 @@
 package utils
 
-import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
+
+import com.google.common.hash.HashFunction
+import com.google.common.hash.Hashing
 
 trait Hasher {
 
@@ -11,42 +12,18 @@ trait Hasher {
   def hash(data: String): String
 }
 
-// Facilitates interacting with the underlying message digest via strings,
-// ensuring the same charset is used throughout for encoding/decoding.
-private[utils] class MessageDigestWrapper private (underlying: MessageDigest, charset: Charset) {
+object SHA256Hasher extends Hasher {
 
-  def digest(data: String): String = {
-    val bytes = underlying.digest(data.getBytes(charset))
-    new String(bytes, charset)
-  }
+  private val sha256: HashFunction = Hashing.sha256()
 
-  def setSalt(salt: String): Unit = {
-    val bytes = salt.getBytes(charset)
-    underlying.update(bytes)
-  }
-}
-
-object MessageDigestWrapper {
-
-  def SHA256: MessageDigestWrapper =
-    new MessageDigestWrapper(MessageDigest.getInstance("SHA-256"), StandardCharsets.UTF_8)
-}
-
-class SHA256Hasher private (messageDigest: MessageDigestWrapper) extends Hasher {
-
-  override def hash(data: String): String = messageDigest.digest(data)
-}
-
-object SHA256Hasher {
+  // Exposed for unit testing
+  def hashWithoutSalt(data: String): String =
+    sha256.hashString(data, StandardCharsets.UTF_8).toString
 
   // Randomly generated global salt to prevent against dictionary attacks
   // https://en.wikipedia.org/wiki/Dictionary_attack
   // DO NOT EDIT!
   val salt = "9Bc671CC30Ee4B24"
 
-  val instance: SHA256Hasher = {
-    val messageDigest = MessageDigestWrapper.SHA256
-    messageDigest.setSalt(salt)
-    new SHA256Hasher(messageDigest)
-  }
+  override def hash(data: String): String = hashWithoutSalt(salt + data)
 }

--- a/app/utils/Hasher.scala
+++ b/app/utils/Hasher.scala
@@ -1,0 +1,52 @@
+package utils
+
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+trait Hasher {
+
+  // Should apply a cryptographic hash function to the data.
+  // https://en.wikipedia.org/wiki/Cryptographic_hash_function
+  def hash(data: String): String
+}
+
+// Facilitates interacting with the underlying message digest via strings,
+// ensuring the same charset is used throughout for encoding/decoding.
+private[utils] class MessageDigestWrapper private (underlying: MessageDigest, charset: Charset) {
+
+  def digest(data: String): String = {
+    val bytes = underlying.digest(data.getBytes(charset))
+    new String(bytes, charset)
+  }
+
+  def setSalt(salt: String): Unit = {
+    val bytes = salt.getBytes(charset)
+    underlying.update(bytes)
+  }
+}
+
+object MessageDigestWrapper {
+
+  def SHA256: MessageDigestWrapper =
+    new MessageDigestWrapper(MessageDigest.getInstance("SHA-256"), StandardCharsets.UTF_8)
+}
+
+class SHA256Hasher private (messageDigest: MessageDigestWrapper) extends Hasher {
+
+  override def hash(data: String): String = messageDigest.digest(data)
+}
+
+object SHA256Hasher {
+
+  // Randomly generated global salt to prevent against dictionary attacks
+  // https://en.wikipedia.org/wiki/Dictionary_attack
+  // DO NOT EDIT!
+  val salt = "9Bc671CC30Ee4B24"
+
+  val instance: SHA256Hasher = {
+    val messageDigest = MessageDigestWrapper.SHA256
+    messageDigest.setSalt(salt)
+    new SHA256Hasher(messageDigest)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,8 @@ val scalaTest = "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Tes
 val enumeratum = "com.beachape" %% "enumeratum" % "1.4.15"
 val sqs = "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.36"
 val slugify = "com.github.slugify" % "slugify" % "2.1.7"
+val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
+val guava = "com.google.guava" % "guava" % "21.0"
 
 libraryDependencies ++= Seq(
     cache,
@@ -66,7 +68,9 @@ libraryDependencies ++= Seq(
     identityCookie,
     enumeratum,
     sqs,
-    slugify
+    slugify,
+    scalaCheck,
+    guava
 )
 dependencyOverrides += "com.typesafe.play" %% "play-json" % "2.4.6"
 

--- a/test/utils/HasherSpec.scala
+++ b/test/utils/HasherSpec.scala
@@ -1,0 +1,22 @@
+package utils
+
+import org.scalacheck.Gen
+import org.scalacheck.Prop._
+import org.scalacheck.Properties
+
+class HasherSpec extends Properties("test") {
+
+  private val browserIdLength = 10
+
+  private val browserIds = Gen.listOfN(browserIdLength, Gen.alphaNumChar).map(_.mkString)
+
+  property("The application hasher must be able to hash browser ids") =
+    forAll(browserIds) { (browserId: String) =>
+      browserId != SHA256Hasher.hash(browserId)
+    }
+
+  property("The application hasher must provide a different hash when a salt is added") =
+    forAll(browserIds) { (browserId: String) =>
+      SHA256Hasher.hash(browserId) != SHA256Hasher.hashWithoutSalt(browserId)
+    }
+}

--- a/test/utils/HasherSpec.scala
+++ b/test/utils/HasherSpec.scala
@@ -19,4 +19,10 @@ class HasherSpec extends Properties("test") {
     forAll(browserIds) { (browserId: String) =>
       SHA256Hasher.hash(browserId) != SHA256Hasher.hashWithoutSalt(browserId)
     }
+
+  property("The application hasher should hash a browser id to the same value each time") =
+    forAll(browserIds) { (browserId: String) =>
+      // 10 chosen arbitrarily
+      (0 to 10).map(_ => SHA256Hasher.hash(browserId)).toSet.size == 1
+    }
 }


### PR DESCRIPTION
cc @guardian/contributions, @adamnfish 

Currently we tag our log requests with certain values (e.g. browser id) to facilitate debugging errors in sentry. Motivated by GDPR classing browser ids as personal data (or something like that!), this pull request:

- includes a `hashValue` field in the `LoggingTag` trait, which is used to signify whether the respective tag value should be hashed when included in log entries
- provides a `Hasher` using the SHA-256 algorithm which is used for hashing logging tags when the respective `hashValue` equals `true`

