### PR TITLE
Store the platform (ios, android) when valued at the time of payment

### DIFF
--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -51,7 +51,17 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
       val idUser = IdentityId.fromRequest(request)
 
 
-      paypalService.storeMetaData(paymentId, request.testAllocations, cmp, intCmp, refererPageviewId, refererUrl, ophanPageviewId, ophanBrowserId, idUser)
+      paypalService.storeMetaData(
+        paymentId = paymentId,
+        testAllocations = request.testAllocations,
+        cmp = cmp,
+        intCmp = intCmp,
+        refererPageviewId = refererPageviewId,
+        refererUrl = refererUrl,
+        ophanPageviewId = ophanPageviewId,
+        ophanBrowserId = ophanBrowserId,
+        idUser = idUser,
+        platform = request.platform)
         .leftMap[AppError](StoreMetaDataError) // not necessary if storeMetaData() returns a custom error type
         .map(data => (payment, data))
     }

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -94,7 +94,8 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config)(i
         refererUrl = form.refererUrl,
         ophanPageviewId = form.ophanPageviewId,
         ophanBrowserId = form.ophanBrowserId,
-        idUser = idUser
+        idUser = idUser,
+        platform = form.platform orElse request.platform
       )
     }
 

--- a/app/controllers/forms/ContributionRequest.scala
+++ b/app/controllers/forms/ContributionRequest.scala
@@ -21,7 +21,8 @@ case class ContributionRequest(
   intcmp: Option[String],
   refererPageviewId: Option[String],
   refererUrl: Option[String],
-  idUser: Option[IdentityId]
+  idUser: Option[IdentityId],
+  platform: Option[String]
 )
 
 object ContributionRequest {
@@ -57,7 +58,8 @@ object ContributionRequest {
       "intcmp" -> optional(text),
       "refererPageviewId" -> optional(text),
       "refererUrl" -> optional(text),
-      "idUser" -> optional(of[IdentityId])
+      "idUser" -> optional(of[IdentityId]),
+      "platform" -> optional(text)
     )(ContributionRequest.apply)(ContributionRequest.unapply)
   )
 

--- a/app/data/ContributionData.scala
+++ b/app/data/ContributionData.scala
@@ -77,7 +77,8 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) extends TagA
           cmp,
           intcmp,
           referer_url,
-          referer_pageview_id
+          referer_pageview_id,
+          platform
         ) VALUES (
           ${pmd.contributionId.id}::uuid,
           ${pmd.created},
@@ -89,7 +90,8 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) extends TagA
           ${pmd.cmp},
           ${pmd.intCmp},
           ${pmd.refererUrl},
-          ${pmd.refererPageviewId}
+          ${pmd.refererPageviewId},
+          ${pmd.platform}
         ) ON CONFLICT(contributionId) DO
         UPDATE SET
           contributionid = excluded.contributionid,
@@ -102,7 +104,8 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) extends TagA
           cmp = excluded.cmp,
           intcmp = excluded.intcmp,
           referer_url = excluded.referer_url,
-          referer_pageview_id = excluded.referer_pageview_id"""
+          referer_pageview_id = excluded.referer_pageview_id,
+          platform = excluded.platform"""
       request.execute()
       pmd
     }

--- a/app/models/ContributionMetaData.scala
+++ b/app/models/ContributionMetaData.scala
@@ -14,5 +14,6 @@ case class ContributionMetaData(
   cmp: Option[String],
   intCmp: Option[String],
   refererPageviewId: Option[String],
-  refererUrl: Option[String]
+  refererUrl: Option[String],
+  platform: Option[String]
 )

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -159,7 +159,8 @@ class PaypalService(
     refererUrl: Option[String],
     ophanPageviewId: Option[String],
     ophanBrowserId: Option[String],
-    idUser: Option[IdentityId]
+    idUser: Option[IdentityId],
+    platform: Option[String]
   )(implicit tags: LoggingTags): EitherT[Future, String, SavedContributionData] = {
 
     def tryToEitherT[A](block: => A): EitherT[Future, String, A] = {
@@ -187,7 +188,8 @@ class PaypalService(
         cmp = cmp,
         intCmp = intCmp,
         refererPageviewId =refererPageviewId,
-        refererUrl = refererUrl
+        refererUrl = refererUrl,
+        platform = platform
       )
 
       val postCode = {

--- a/app/services/StripeService.scala
+++ b/app/services/StripeService.scala
@@ -39,7 +39,8 @@ class StripeService(
     refererUrl: Option[String],
     ophanPageviewId: String,
     ophanBrowserId: Option[String],
-    idUser: Option[IdentityId]
+    idUser: Option[IdentityId],
+    platform: Option[String]
   )(implicit tags: LoggingTags): EitherT[Future, String, SavedContributionData] = {
 
     // Fire and forget: we don't want to stop the user flow
@@ -66,7 +67,8 @@ class StripeService(
       cmp = cmp,
       intCmp = intCmp,
       refererPageviewId = refererPageviewId,
-      refererUrl = refererUrl
+      refererUrl = refererUrl,
+      platform = platform
     )
     val contributor = Contributor(
       email = charge.receipt_email,


### PR DESCRIPTION
This allow us to store and eventually measure which contributions are coming from the apps

It is linked to this PR that updates the schema:
https://github.com/guardian/contributions-platform/pull/50

once the above is merged I'll update the schema in prod and will deploy this project.

@guardian/contributions 
cc @jorgeazevedo
