### PR TITLE
Adding fix for dodgy android browsers which set localstorage to null

### DIFF
--- a/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -19,6 +19,7 @@
         'querySelector' in document
         && 'addEventListener' in window
         && 'localStorage' in window
+        && localStorage !== null
         && 'sessionStorage' in window
         && 'bind' in Function
         && (('XMLHttpRequest' in window && 'withCredentials' in new XMLHttpRequest())


### PR DESCRIPTION
Some versions of android browsers have `localStorage` on the `window` object, but it is set to `null`. This confuses our `isModern` check, and throws a uncaught exception when trying to access `localStorage`.
This PR marks these dodgy android browsers as old, and no longer accesses `localStorage`.

@jorgeazevedo @guardian/contributions 