### PR TITLE
Landing page test update

### DIFF
--- a/app/abtests/Test.scala
+++ b/app/abtests/Test.scala
@@ -46,7 +46,7 @@ object Test {
 
   val stripeTest = Test("Stripe checkout", 100.percent, 0.percent, Seq(Variant("stripe")))
 
-  val landingPageTest = Test("Landing page", 100.percent, 0.percent, Seq(Variant("with-copy")), cmpCheck("gdnwb_copts.*_banner".r))
+  val landingPageTest = Test("Landing page", 100.percent, 0.percent, Seq(Variant("with-copy")), cmpCheck("(gdnwb_copts(.*_banner)|(.*_thrasher))".r))
 
   val allTests: Set[Test] = Set(stripeTest, landingPageTest)
 

--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -21,11 +21,11 @@
 )
 
 @defining { (block: Html) =>
-    @if(inLandingPageTest) {
-        @contributionsAlt(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)
+    @if(intCmpCode.exists(_.contains("_this_land_"))) {
+        @contributionsThisLandIsYourLand(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)
     } else {
-        @if(intCmpCode.exists(_.contains("_this_land_"))) {
-            @contributionsThisLandIsYourLand(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)
+        @if(inLandingPageTest) {
+            @contributionsAlt(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)
         } else {
             @contributionsMain(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)
         }


### PR DESCRIPTION
cc @guardian/contributions 
cc @sammorrisdesign 

Amanda wants readers coming to the contributions homepage from a generic thrasher to see the _Epic-like_ variant. This pull request implements this.

Additionally, the _this land_ variant has been given precedent e.g. if a reader has the campaign code `gdnwb_copts_this_land_thrasher` they will be shown the _this land_ variant over the _Epic-like_ variant.