### PR TITLE
Fix webpack-dev-server on HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This will start:
  - grunt watch to compile assets such as css
  - the webpack dev server on the port 9111, proxying calls to the play app for everything but js
 
-Making a request to [http://localhost:9111](http://localhost:9111) should give you the homepage.
+Making a request to [https://localhost:9111](https://localhost:9111) should give you the homepage.
 
 To make the site reachable as [https://contribute.thegulocal.com](https://contribute.thegulocal.com) (necessary for register/sign-in functionality) you then need to make sure NGINX is configured and running as described in [`/nginx/README.md`](./nginx/README.md).
 

--- a/nginx/contributions.conf
+++ b/nginx/contributions.conf
@@ -2,7 +2,7 @@ server {
     server_name contribute.thegulocal.com;
 
     location / {
-        proxy_pass http://localhost:9111/;
+        proxy_pass https://localhost:9111/;
         proxy_set_header Host $http_host;
     }
 }
@@ -23,7 +23,7 @@ server {
     ssl_prefer_server_ciphers on;
 
     location / {
-        proxy_pass http://localhost:9111/;
+        proxy_pass https://localhost:9111/;
         proxy_set_header Host $http_host;
     }
 }

--- a/nginx/contributions.conf
+++ b/nginx/contributions.conf
@@ -3,6 +3,7 @@ server {
 
     location / {
         proxy_pass https://localhost:9111/;
+        proxy_max_temp_file_size 0;
         proxy_set_header Host $http_host;
     }
 }
@@ -24,6 +25,7 @@ server {
 
     location / {
         proxy_pass https://localhost:9111/;
+        proxy_max_temp_file_size 0;
         proxy_set_header Host $http_host;
     }
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "time-grunt": "^1.4.0",
     "vinyl-fs": "2.4.3",
     "webpack": "^2.2.1",
-    "webpack-dev-server": "^2.3.0",
+    "webpack-dev-server": "^2.5.0",
     "whatwg-fetch": "^1.0.0"
   },
   "jest": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,6 +73,8 @@ module.exports = {
 
     devServer: {
         https: true,
+        
+        hot: true,
 
         port: 9111,
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,11 +72,21 @@ module.exports = {
     devtool: 'source-map',
 
     devServer: {
+        https: true,
+
+        port: 9111,
+
         proxy: {
             '**': {
                 target: 'http://localhost:9112',
                 secure: false
             }
-        }
-    }
-};
+        },
+
+        public: 'contribute.thegulocal.com:9111'
+    },
+
+    plugins: [
+        new webpack.HotModuleReplacementPlugin()
+    ]
+}


### PR DESCRIPTION
`webpack-dev-server` is currently broken when accessing the site via contribute.thegulocal.com. 
This fixes everything 