### PR TITLE
Query parameter added to disable stripe payment option

### DIFF
--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -39,7 +39,8 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken) ex
 
   def redirectToUk = (NoCacheAction andThen MobileSupportAction) { implicit request => redirectWithQueryParams(routes.Contributions.contribute(UK).url) }
 
-  private def redirectWithQueryParams(destinationUrl: String)(implicit request: Request[Any]) = redirectWithCampaignCodes(destinationUrl, Set("mcopy", "skipAmount", "highlight"))
+  private def redirectWithQueryParams(destinationUrl: String)(implicit request: Request[Any]) =
+    redirectWithCampaignCodes(destinationUrl, Set("mcopy", "skipAmount", "highlight", "disableStripe"))
 
   def postPayment(countryGroup: CountryGroup) = NoCacheAction { implicit request =>
     val pageInfo = PageInfo(

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -17,6 +17,8 @@ import utils.MaxAmount
 import utils.RequestCountry._
 import views.support._
 
+import scala.util.Try
+
 class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken) extends Controller with Redirect {
 
   val social: Set[Social] = Set(
@@ -61,6 +63,9 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken) ex
       val refererPageviewId = request.getQueryString("REFPVID")
       val refererUrl = request.headers.get("referer")
 
+      val disableStripe = request.getQueryString("disableStripe")
+        .flatMap(value => Try(value.toBoolean).toOption).getOrElse(false)
+
       val pageInfo = PageInfo(
         title = "Support the Guardian | Contribute today",
         url = request.path,
@@ -85,7 +90,8 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken) ex
         creditCardExpiryYears,
         errorMessage,
         CSRF.getToken.map(_.value),
-        request.isAllocated(Test.landingPageTest, "with-copy")
+        request.isAllocated(Test.landingPageTest, "with-copy"),
+        disableStripe
       ))
     }
   }

--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -17,7 +17,8 @@
     creditCardExpiryYears: List[Int],
     errorMessage: Option[String],
     csrfToken: Option[String],
-    inLandingPageTest: Boolean
+    inLandingPageTest: Boolean,
+    disableStripe: Boolean
 )
 
 @defining { (block: Html) =>
@@ -50,6 +51,7 @@
             @for(refUrl <- refererUrl) {
                 data-referrer-url="@refUrl"
                 }
+        data-disable-stripe="@disableStripe"
         >
         </section>
 

--- a/assets/javascripts/src/components/Main.jsx
+++ b/assets/javascripts/src/components/Main.jsx
@@ -40,7 +40,8 @@ function mapStateToProps(state) {
         cardPay: state.page.cardPay,
         paymentError: state.page.paymentError,
         amounts: abTests.amounts(state.data.abTests),
-        countryGroup: state.data.countryGroup
+        countryGroup: state.data.countryGroup,
+        disableStripe: state.data.disableStripe
     };
 }
 

--- a/assets/javascripts/src/components/Navigation.jsx
+++ b/assets/javascripts/src/components/Navigation.jsx
@@ -24,6 +24,7 @@ export default class Navigation extends React.Component {
         const showBack = !processing && this.props.page !== PAGES.CONTRIBUTION;
         const showForward = !processing && this.props.page == PAGES.DETAILS;
         const showPay = !processing && !!this.props.amount && this.props.page === PAGES.PAYMENT;
+        const showStripePaymentOption = isFirstPage && !this.props.disableStripe;
 
         return <div className={'contribute-navigation ' + this.classNameFor(this.props.page)}>
         {showBack && <Back type="button" className="action--secondary contribute-navigation__back hidden-mobile" onClick={this.props.goBack}>Back</Back>}
@@ -31,7 +32,7 @@ export default class Navigation extends React.Component {
         {(!stripeCheckout && showForward) && <Forward className="contribute-navigation__button contribute-navigation__next hidden-mobile">Next</Forward>}
         {(!stripeCheckout && showPay) && <Forward className='contribute-navigation__button action--pay' onClick={this.props.payWithCard}>Pay {this.props.currency.prefix}{this.props.currency.symbol}{this.props.amount}</Forward>}
         {showMobileBack && <Back className="action--secondary contribute-navigation__back show-mobile" onClick={this.props.jumpToFirstPage}>Back</Back>}
-        {isFirstPage &&  <Forward className="contribute-navigation__button action action--button contribute-navigation__next action--next contribute_card__button" onClick={this.props.clearPaymentFlags}>{"Contribute with debit/credit card"}</Forward>}
+        {showStripePaymentOption &&  <Forward className="contribute-navigation__button action action--button contribute-navigation__next action--next contribute_card__button" onClick={this.props.clearPaymentFlags}>{"Contribute with debit/credit card"}</Forward>}
         {isFirstPage && <Forward className="contribute-navigation__button action action--button  paypal__button" onClick={this.props.payWithPaypal}>Contribute with</Forward>}
         {processing && <Spinner text="Processing" />}
         </div>;

--- a/assets/javascripts/src/components/form-wrapper/DesktopWrapper.jsx
+++ b/assets/javascripts/src/components/form-wrapper/DesktopWrapper.jsx
@@ -32,6 +32,7 @@ export default class DesktopWrapper extends React.Component {
                             mobile={false}
                             clearPaymentFlags={this.props.clearPaymentFlags}
                             stripeCheckout={this.props.stripeCheckout}
+                            disableStripe={this.props.disableStripe}
                         />
                     </div>
 

--- a/assets/javascripts/src/components/form-wrapper/MobileWrapper.jsx
+++ b/assets/javascripts/src/components/form-wrapper/MobileWrapper.jsx
@@ -40,6 +40,7 @@ export default class MobileWrapper extends React.Component {
                         mobile={true}
                         clearPaymentFlags={this.props.clearPaymentFlags}
                         stripeCheckout={this.props.stripeCheckout}
+                        disableStripe={this.props.disableStripe}
                     />
 
                     {!this.props.processing  && p== PAGES.CONTRIBUTION && <LegalNotice countryGroup={this.props.countryGroup}/>}

--- a/assets/javascripts/src/modules/contribute.es6
+++ b/assets/javascripts/src/modules/contribute.es6
@@ -86,7 +86,8 @@ function appDataFrom(container) {
         intCmpCode: container.getAttribute('data-int-cmp-code'),
         refererPageviewId: container.getAttribute('data-referrer-pageview-id'),
         refererUrl: container.getAttribute('data-referrer-url'),
-        csrfToken: container.getAttribute('data-csrf-token')
+        csrfToken: container.getAttribute('data-csrf-token'),
+        disableStripe: container.getAttribute('data-disable-stripe') === 'true'
     };
 }
 

--- a/assets/javascripts/src/reducers/data.es6
+++ b/assets/javascripts/src/reducers/data.es6
@@ -21,7 +21,8 @@ const initialState = {
     stripe: {
         handler: null,
         token: null,
-    }
+    },
+    disableStripe: false
 };
 
 /**


### PR DESCRIPTION
cc @guardian/contributions 

If the contributions home page is hit with query parameter `disableStripe=true` then the Stripe payment option is not included. 

The reason for this pull request is to facilitate the making payments easier test - it allows us to show readers in the control only the option to pay with Paypal (as readers in the other variants will only have this option).