### PR TITLE
Remove ELB session stickiness

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -176,9 +176,6 @@
         ConnectionDrainingPolicy:
           Enabled: true
           Timeout: 60
-        LBCookieStickinessPolicy:
-          - CookieExpirationPeriod: 1800
-            PolicyName: CookieBasedPolicy
     LoadBalancerSecurityGroup:
       Type: AWS::EC2::SecurityGroup
       Properties:


### PR DESCRIPTION
This is preventing caching in Fastly (due to the Set-Cookie header being
set by the ELB). We need caching for the moment because we're about to
send a large amount of traffic to the app from the PayPal-Epic iframe.

@guardian/contributions 