### PR TITLE
Don't hard code Paypal error

### DIFF
--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -63,7 +63,7 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
       )
 
     def redirectUrl(error: Option[PaymentError]) =
-      routes.Contributions.contribute(countryGroup, Some(PaypalError)).url
+      routes.Contributions.contribute(countryGroup, error).url
 
     def notOkResult(message: String): Result = {
       error(s"Error executing PayPal payment: $message")


### PR DESCRIPTION
cc @guardian/contributions 

This stops the Paypal error being hard-coded in the redirect URL.