### PR TITLE
Add cloudwatch metrics and logging - expurgated version

### DIFF
--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -112,7 +112,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       .map(mobileRedirectUrl)
       .filter(_ => request.isIos)
 
-    info(s"Thank you page displayed for paypal payment id: ${request.id}")
+    info(s"Thank you page displayed. Request id: ${request.id}")
     cloudWatchMetrics.logThankYouPage()
 
     Ok(views.html.giraffe.thankyou(PageInfo(

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -9,7 +9,7 @@ import com.gu.i18n._
 import com.netaporter.uri.dsl._
 import configuration.Config
 import models.ContributionAmount
-import monitoring.TagAwareLogger
+import monitoring.{CloudWatchMetrics, LoggingTagsProvider, TagAwareLogger}
 import play.api.mvc._
 import play.filters.csrf.{CSRF, CSRFAddToken}
 import services.PaymentServices
@@ -19,7 +19,8 @@ import views.support._
 
 import scala.util.Try
 
-class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken) extends Controller with Redirect {
+class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cloudWatchMetrics: CloudWatchMetrics)
+  extends Controller with Redirect with TagAwareLogger with LoggingTagsProvider {
 
   val social: Set[Social] = Set(
     Twitter("I've just contributed to the Guardian. Join me in supporting independent journalism https://membership.theguardian.com/contribute"),
@@ -51,6 +52,8 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken) ex
       description = Some("By making a contribution, you’ll be supporting independent journalism that speaks truth to power"),
       customSignInUrl = Some((Config.idWebAppUrl / "signin") ? ("skipConfirmation" -> "true"))
     )
+    info(s"Paypal post-payment page displayed for request: ${request.id}")
+    cloudWatchMetrics.logPaypalPostPaymentPage()
     Ok(views.html.giraffe.postPayment(pageInfo, countryGroup))
   }
 
@@ -79,6 +82,9 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken) ex
       val maxAmountInLocalCurrency = MaxAmount.forCurrency(countryGroup.currency)
       val creditCardExpiryYears = CreditCardExpiryYears(LocalDate.now.getYear, 10)
 
+      info(s"Home page displayed for request id: ${request.id}")
+      cloudWatchMetrics.logHomePage()
+
       Ok(views.html.giraffe.contribute(
         pageInfo,
         maxAmountInLocalCurrency,
@@ -105,6 +111,9 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken) ex
       .flatMap(ContributionAmount.apply)
       .map(mobileRedirectUrl)
       .filter(_ => request.isIos)
+
+    info(s"Thank you page displayed for paypal payment id: ${request.id}")
+    cloudWatchMetrics.logThankYouPage()
 
     Ok(views.html.giraffe.thankyou(PageInfo(
       title = title,

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -46,7 +46,7 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
     val paypalService = paymentServices.paypalServiceFor(request)
     val platform = request.platform.getOrElse("unknown")
 
-    info(s"Attempting paypal payment for id: ${request.id} from platform $platform")
+    info(s"Attempting paypal payment for id: ${request.id}")
     cloudWatchMetrics.logPaypalPaymentAttempt()
 
     def storeMetaData(payment: Payment) =
@@ -83,7 +83,7 @@ class PaypalController(ws: WSClient, paymentServices: PaymentServices, checkToke
           val session = List("email" -> email) ++ amount.map("amount" -> _.show)
           redirectWithCampaignCodes(routes.Contributions.postPayment(countryGroup).url).addingToSession(session: _ *)
       }
-      info(s"Paypal payment successful. Request id: ${request.id}, Payment id: ${payment.getId}")
+      info(s"Paypal payment successful. Request id: ${request.id}.")
       cloudWatchMetrics.logPaypalPaymentSuccess()
       response.setCookie[ContribTimestampCookieAttributes](payment.getCreateTime)
     }

--- a/app/monitoring/CloudWatch.scala
+++ b/app/monitoring/CloudWatch.scala
@@ -1,0 +1,25 @@
+package monitoring
+
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.regions.Regions.EU_WEST_1
+import com.amazonaws.services.cloudwatch.model.{PutMetricDataRequest, PutMetricDataResult}
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsync, AmazonCloudWatchAsyncClient}
+import com.gu.aws.CredentialsProvider
+import com.typesafe.scalalogging.LazyLogging
+
+
+object CloudWatch {
+  def build(): AmazonCloudWatchAsync = AmazonCloudWatchAsyncClient.asyncBuilder
+    .withCredentials(CredentialsProvider)
+    .withRegion(EU_WEST_1).build()
+
+  object LoggingAsyncHandler extends AsyncHandler[PutMetricDataRequest, PutMetricDataResult] with LazyLogging {
+    def onError(exception: Exception): Unit = {
+      logger.info(s"CloudWatch PutMetricDataRequest error: ${exception.getMessage}}")
+    }
+
+    def onSuccess(request: PutMetricDataRequest, result: PutMetricDataResult): Unit = {
+      logger.trace("CloudWatch PutMetricDataRequest - success")
+    }
+  }
+}

--- a/app/monitoring/CloudWatchMetrics.scala
+++ b/app/monitoring/CloudWatchMetrics.scala
@@ -1,0 +1,125 @@
+package monitoring
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync
+import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest}
+import configuration.Config
+import play.api.libs.json.Json
+
+
+/**
+  * Created by mmcnamara on 12/07/2017.
+  */
+class CloudWatchMetrics(cloudWatchClient: AmazonCloudWatchAsync) extends TagAwareLogger {
+
+  val stage: String = Config.stage
+  val application = "contributions" // This sets the namespace for Custom Metrics in AWS (see CloudWatch)
+
+  val stageDimension: Dimension = new Dimension().withName("Stage").withValue(stage)
+
+  def put(name: String, count: Double): Unit = {
+    val metric =
+      new MetricDatum()
+        .withValue(count)
+        .withMetricName(name)
+        .withUnit("Count")
+        .withDimensions(stageDimension)
+
+    val request = new PutMetricDataRequest().
+      withNamespace(application).withMetricData(metric)
+
+    cloudWatchClient.putMetricDataAsync(request, CloudWatch.LoggingAsyncHandler)
+  }
+
+  def put(metricName: String): Unit = {
+    put(metricName, 1)
+  }
+
+  def logHomePage(): Unit = {
+    put("contribution-home-page")
+  }
+  def logPaypalPostPaymentPage(): Unit = {
+    put("contribution-paypal-post-payment-page")
+  }
+  def logThankYouPage(): Unit = {
+    put("contribution-thank-you-page")
+  }
+
+
+  def logStripePaymentAttempt(platform: String): Unit = {
+    put(s"contribution-stripe-payment-attempt-from-$platform")
+  }
+
+  def logStripePaymentSuccess(platform: String): Unit = {
+    put(s"contribution-stripe-payment-success-from-$platform")
+  }
+
+  def logStripePaymentFailure(platform: String): Unit = {
+    put(s"contribution-stripe-payment-failure-from-$platform")
+  }
+
+  def logStripeHookParsed(): Unit = {
+    put("contribution-stripe-hook-parsed")
+  }
+
+  def logStripeHookParseError(): Unit = {
+    put("contribution-stripe-hook-parse-error")
+  }
+
+  def logStripeHookProcessed(): Unit = {
+    put("contribution-stripe-hook-processed")
+  }
+
+  def logStripeHookProcessError(): Unit = {
+    put("contribution-stripe-hook-processing-error")
+  }
+
+
+  def logPaypalAuthAttempt(): Unit = {
+    put("contribution-paypal-authorisation-attempt")
+  }
+
+  def logPaypalAuthSuccess(): Unit = {
+    put("contribution-paypal-authorisation-success")
+  }
+
+  def logPaypalAuthFailure(): Unit = {
+    put("contribution-paypal-authorisation-failure")
+  }
+
+  def logPaypalPaymentAttempt(): Unit = {
+    put("contribution-paypal-payment-attempt")
+  }
+
+  def logPaypalPaymentSuccess(): Unit = {
+    put("contribution-paypal-payment-success")
+  }
+
+  def logPaypalPaymentFailure(): Unit = {
+    put("contribution-paypal-payment-failed-error")
+  }
+
+  def logPaypalHookAttempt(): Unit = {
+    put("contribution-paypal-hook-attempt")
+  }
+
+  def logPaypalHookParsed(): Unit = {
+    put("contribution-paypal-hook-parsed")
+  }
+
+  def logPaypalHookProcessed(): Unit = {
+    put("contribution-paypal-hook-processed")
+  }
+
+  def logPaypalHookParseError(): Unit = {
+    put("contribution-paypal-hook-parse-error")
+  }
+
+  def logPaypalHookProcessError(): Unit = {
+    put("contribution-paypal-hook-processing-error")
+  }
+
+  def logPaypalHookInvalidRequest(): Unit = {
+    put("contribution-paypal-hook-invalid-request")
+  }
+
+}

--- a/app/monitoring/LoggingTags.scala
+++ b/app/monitoring/LoggingTags.scala
@@ -81,6 +81,9 @@ trait TagAwareLogger extends LazyLogging {
   def info(msg: String)(implicit tags: LoggingTags): Unit =
     withTags(logger.info(msg))
 
+  def warn(msg: String)(implicit tags: LoggingTags): Unit =
+    withTags(logger.warn(msg))
+
   def error(msg: String, t: Throwable)(implicit tags: LoggingTags): Unit =
     withTags(logger.error(msg, t))
 

--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,7 @@ val sqs = "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.36"
 val slugify = "com.github.slugify" % "slugify" % "2.1.7"
 val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
 val guava = "com.google.guava" % "guava" % "21.0"
+val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.11.95"
 
 libraryDependencies ++= Seq(
     cache,
@@ -70,7 +71,8 @@ libraryDependencies ++= Seq(
     sqs,
     slugify,
     scalaCheck,
-    guava
+    guava,
+    awsCloudwatch
 )
 dependencyOverrides += "com.typesafe.play" %% "play-json" % "2.4.6"
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -33,7 +33,7 @@
   <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />
   <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
-  <root level="WARN">
+  <root level="INFO">
     <appender-ref ref="ASYNCFILE" />
     <appender-ref ref="ASYNCSTDOUT" />
   </root>


### PR DESCRIPTION
This pull requests adds improves logging and adds cloudwatch metrics for Stripe and Paypal payments.

Testing:
Confirmed that payments work locally


@guardian/contributions 
