### PR TITLE
Adding complete event to ab test data

### DIFF
--- a/app/abtests/Test.scala
+++ b/app/abtests/Test.scala
@@ -67,7 +67,7 @@ case class Variant(name: String) {
 
 case class Allocation(test: Test, variant: Variant) {
   val toOphanJson: JsObject = {
-    Json.obj(test.slug -> Json.obj("variantName" -> variant.slug))
+    Json.obj(test.slug -> Json.obj("variantName" -> variant.slug, "complete" -> false))
   }
 }
 


### PR DESCRIPTION
This adds the `complete` part to the ab test data we pass as part of the acquisition event. This is required by Ophan's ab test parsing model!

@guardian/contributions 

