### PR TITLE
Use wildcard certificate for contribute.thegulocal.com

### DIFF
--- a/nginx/contributions.conf
+++ b/nginx/contributions.conf
@@ -14,8 +14,8 @@ server {
     server_name contribute.thegulocal.com;
 
     ssl on;
-    ssl_certificate keys/contribute-thegulocal-com-exp2017-07-19-bundle.crt;
-    ssl_certificate_key keys/contribute-thegulocal-com-exp2017-07-19.key;
+    ssl_certificate keys/wildcard-thegulocal-com-exp2019-01-09.crt;
+    ssl_certificate_key keys/wildcard-thegulocal-com-exp2019-01-09.key;
 
     ssl_session_timeout 5m;
 

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -6,13 +6,9 @@ NGINX_HOME=$(nginx -V 2>&1 | grep 'configure arguments:' | sed 's#.*conf-path=\(
 
 sudo mkdir -p ${NGINX_HOME}/sites-enabled
 sudo ln -fs ${DIR}/contributions.conf ${NGINX_HOME}/sites-enabled/contributions.conf
-aws s3 cp s3://identity-local-ssl/contribute-thegulocal-com-exp2017-07-19-bundle.crt ${GU_KEYS}/ --profile membership
-aws s3 cp s3://identity-local-ssl/contribute-thegulocal-com-exp2017-07-19.key ${GU_KEYS}/ --profile membership
 
-aws s3 cp s3://identity-local-ssl/wildcard-thegulocal-com-exp2019-01-09.crt ${NGINX_HOME} --profile membership
-
-aws s3 cp s3://identity-local-ssl/wildcard-thegulocal-com-exp2019-01-09.key ${NGINX_HOME} --profile membership
-
+aws s3 cp s3://identity-local-ssl/wildcard-thegulocal-com-exp2019-01-09.crt ${GU_KEYS} --profile membership
+aws s3 cp s3://identity-local-ssl/wildcard-thegulocal-com-exp2019-01-09.key ${GU_KEYS} --profile membership
 
 sudo ln -fs ${GU_KEYS}/ ${NGINX_HOME}/keys
 


### PR DESCRIPTION
The previous cert has expired, this one is valid until 2019.

@guardian/contributions 