### PR TITLE
logging added when body parsers fail

### DIFF
--- a/app/controllers/BodyParsers.scala
+++ b/app/controllers/BodyParsers.scala
@@ -13,12 +13,8 @@ object BodyParsers {
   implicit class BodyParserOps[A](val bodyParser: BodyParser[A]) extends AnyVal {
     def logFailure(f: RequestHeader => Unit)(implicit ec: ExecutionContext): BodyParser[A] = new BodyParser[A] {
       import cats.syntax.either._
-      override def apply(header: RequestHeader): Accumulator[ByteString, Either[Result, A]] = {
-        bodyParser(header).map(_.leftMap { result =>
-          f(header)
-          result
-        })
-      }
+      override def apply(header: RequestHeader): Accumulator[ByteString, Either[Result, A]] =
+        bodyParser(header).map(_.leftMap { result => f(header); result })
     }
   }
 

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -174,7 +174,7 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
   private val authorizeBodyParser = {
     import BodyParsers._
     parse.json[AuthRequest].logFailure { implicit header =>
-      error("unable to parse body to an auth request")
+      error("Unable to parse body to an auth request")
     }
   }
 
@@ -266,7 +266,7 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
   private val updateMetadataBodyParser = {
     import BodyParsers._
     parse.form(metadataUpdateForm).logFailure { implicit header =>
-      error("unable to parse body to a meta data update form")
+      error("Unable to parse body to a meta data update form")
     }
   }
 


### PR DESCRIPTION
cc @guardian/contributions 

Logs parsing failures to facilitate investigating errors. 

_Have you gone through the contributions flow for all test variants ?_ __Yes__
