### PR TITLE
Workaround for test users coming from support.theguardian.com

### DIFF
--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -42,7 +42,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
 
     val form = request.body
 
-    val stripe = paymentServices.stripeServiceFor(request)
+    val stripe = paymentServices.stripeServiceFor(form.name)
     val idUser = IdentityId.fromRequest(request) orElse form.idUser
 
     val countryGroup = form.currency match {


### PR DESCRIPTION
These users aren’t sending the auth cookies, so this identifies test users based on the name in the form