### PR TITLE
A better id field in logs for debugging

### DIFF
--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -56,14 +56,14 @@ object CommonActions {
   implicit class MobileSupportRequest[A](val request: Request[A]) extends AnyVal {
 
     private def _platform = request.getQueryString("platform").orElse(request.session.get("platform")).getOrElse("web")
-    private def _sessionId = request.cookies.get("PLAY_SESSION").map(_.value).getOrElse("unknown")
+    private def _sessionId = request.cookies.get("gu.contributions.csrf-token").map(_.value).getOrElse("Unknown")
 
     def platform: String = request.body match {
       case body: ContributionRequest => body.platform.getOrElse(_platform)
       case _ => _platform
     }
 
-    def sessionId: String = _sessionId
+    def sessionIdFragment: String = _sessionId.takeRight(8)
 
     def isAndroid: Boolean = platform == "android"
     def isIos: Boolean = platform == "ios"

--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -56,11 +56,14 @@ object CommonActions {
   implicit class MobileSupportRequest[A](val request: Request[A]) extends AnyVal {
 
     private def _platform = request.getQueryString("platform").orElse(request.session.get("platform")).getOrElse("web")
+    private def _sessionId = request.cookies.get("PLAY_SESSION").map(_.value).getOrElse("unknown")
 
     def platform: String = request.body match {
       case body: ContributionRequest => body.platform.getOrElse(_platform)
       case _ => _platform
     }
+
+    def sessionId: String = _sessionId
 
     def isAndroid: Boolean = platform == "android"
     def isIos: Boolean = platform == "ios"

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -52,7 +52,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       description = Some("By making a contribution, you’ll be supporting independent journalism that speaks truth to power"),
       customSignInUrl = Some((Config.idWebAppUrl / "signin") ? ("skipConfirmation" -> "true"))
     )
-    info(s"Paypal post-payment page displayed for request: ${request.id}, platform: ${request.platform}.")
+    info(s"Paypal post-payment page displayed for request: ${request.sessionId}, platform: ${request.platform}.")
     cloudWatchMetrics.logPostPaymentPageDisplayed(request.paymentProvider, request.platform)
     Ok(views.html.giraffe.postPayment(pageInfo, countryGroup))
   }
@@ -82,7 +82,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       val maxAmountInLocalCurrency = MaxAmount.forCurrency(countryGroup.currency)
       val creditCardExpiryYears = CreditCardExpiryYears(LocalDate.now.getYear, 10)
 
-      info(s"Home page displayed for request id: ${request.id}, platform: ${request.platform}.")
+      info(s"Home page displayed for session id: ${request.sessionId}, platform: ${request.platform}.")
       cloudWatchMetrics.logHomePage(request.platform)
 
       Ok(views.html.giraffe.contribute(
@@ -112,7 +112,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       .map(mobileRedirectUrl)
       .filter(_ => request.isIos)
 
-    info(s"Thank you page displayed. Request id: ${request.id}, platform: ${request.platform}. Payment method used was: ${request.paymentProvider.getOrElse("unknown")}.")
+    info(s"Thank you page displayed. Session id: ${request.sessionId}, platform: ${request.platform}. Payment method used was: ${request.paymentProvider.getOrElse("unknown")}.")
     cloudWatchMetrics.logThankYouPageDisplayed(request.paymentProvider, request.platform)
 
     Ok(views.html.giraffe.thankyou(PageInfo(

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -52,7 +52,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       description = Some("By making a contribution, you’ll be supporting independent journalism that speaks truth to power"),
       customSignInUrl = Some((Config.idWebAppUrl / "signin") ? ("skipConfirmation" -> "true"))
     )
-    info(s"Paypal post-payment page displayed for request: ${request.sessionId}, platform: ${request.platform}.")
+    info(s"Paypal post-payment page displayed for session id: ${request.sessionIdFragment}, platform: ${request.platform}.")
     cloudWatchMetrics.logPostPaymentPageDisplayed(request.paymentProvider, request.platform)
     Ok(views.html.giraffe.postPayment(pageInfo, countryGroup))
   }
@@ -82,7 +82,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       val maxAmountInLocalCurrency = MaxAmount.forCurrency(countryGroup.currency)
       val creditCardExpiryYears = CreditCardExpiryYears(LocalDate.now.getYear, 10)
 
-      info(s"Home page displayed for session id: ${request.sessionId}, platform: ${request.platform}.")
+      info(s"Home page displayed for session id: ${request.sessionIdFragment}, platform: ${request.platform}.")
       cloudWatchMetrics.logHomePage(request.platform)
 
       Ok(views.html.giraffe.contribute(
@@ -112,7 +112,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       .map(mobileRedirectUrl)
       .filter(_ => request.isIos)
 
-    info(s"Thank you page displayed. Session id: ${request.sessionId}, platform: ${request.platform}. Payment method used was: ${request.paymentProvider.getOrElse("unknown")}.")
+    info(s"Thank you page displayed. Session id: ${request.sessionIdFragment}, platform: ${request.platform}. Payment method used was: ${request.paymentProvider.getOrElse("unknown")}.")
     cloudWatchMetrics.logThankYouPageDisplayed(request.paymentProvider, request.platform)
 
     Ok(views.html.giraffe.thankyou(PageInfo(

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -45,7 +45,7 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
 
     val paypalService = paymentServices.paypalServiceFor(request)
 
-    info(s"Attempting paypal payment for id: ${request.sessionId}")
+    info(s"Attempting paypal payment for id: ${request.sessionIdFragment}")
     cloudWatchMetrics.logPaymentAttempt(PaymentProvider.Paypal, request.platform)
 
     def storeMetaData(payment: Payment) =
@@ -64,7 +64,7 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
       )
 
     def notOkResult(message: String): Result = {
-      error(s"Error executing PayPal payment for session id: ${request.sessionId} \n\t error message: $message")
+      error(s"Error executing PayPal payment for session id: ${request.sessionIdFragment} \n\t error message: $message")
       cloudWatchMetrics.logPaymentFailure(PaymentProvider.Paypal, request.platform)
       render {
         case Accepts.Json() => BadRequest(JsNull)
@@ -82,7 +82,7 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
           val session = List("email" -> email, PaymentProvider.sessionKey -> PaymentProvider.Paypal.entryName) ++ amount.map("amount" -> _.show)
           redirectWithCampaignCodes(routes.Contributions.postPayment(countryGroup).url).addingToSession(session: _ *)
       }
-      info(s"Paypal payment from platform: ${request.platform} is successful. Session id: ${request.sessionId}.")
+      info(s"Paypal payment from platform: ${request.platform} is successful. Session id: ${request.sessionIdFragment}.")
       cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Paypal, request.platform)
       response.setCookie[ContribTimestampCookieAttributes](payment.getCreateTime)
     }
@@ -173,7 +173,7 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
 
   def authorize = checkToken {
     NoCacheAction.async(parse.json[AuthRequest]) { implicit request =>
-      info(s"Attempting to obtain paypal auth response. Session id: ${request.sessionId}. Platform: ${request.platform}.")
+      info(s"Attempting to obtain paypal auth response. Session id: ${request.sessionIdFragment}. Platform: ${request.platform}.")
       cloudWatchMetrics.logPaymentAuthAttempt(PaymentProvider.Paypal, request.platform)
       val authRequest = request.body
       val amount = capAmount(authRequest.amount, authRequest.countryGroup.currency)
@@ -193,12 +193,12 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
 
       payment.subflatMap(AuthResponse.fromPayment).fold(
         err => {
-          error(s"Error getting PayPal auth response for session id: ${request.sessionId}, platform: ${request.platform}.\n\t error message: $err")
+          error(s"Error getting PayPal auth response for session id: ${request.sessionIdFragment}, platform: ${request.platform}.\n\t error message: $err")
           cloudWatchMetrics.logPaymentAuthFailure(PaymentProvider.Paypal, request.platform)
           InternalServerError("Error getting PayPal auth url")
         },
         authResponse => {
-          info(s"Paypal payment auth response successfully obtained for session id: ${request.sessionId}, platform: ${request.platform}.")
+          info(s"Paypal payment auth response successfully obtained for session id: ${request.sessionIdFragment}, platform: ${request.platform}.")
           cloudWatchMetrics.logPaymentAuthSuccess(PaymentProvider.Paypal, request.platform)
           Ok(Json.toJson(authResponse))
         }
@@ -210,7 +210,7 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
     val bodyText = request.body
     val bodyJson = Json.parse(request.body)
 
-    info(s"Paypal hook attempt made for session id: ${request.sessionId}, Platform: ${request.platform}")
+    info(s"Paypal hook attempt made for session id: ${request.sessionIdFragment}, Platform: ${request.platform}")
     cloudWatchMetrics.logHookAttempt(PaymentProvider.Paypal, request.platform)
 
     val paypalService = paymentServices.paypalServiceFor(request)
@@ -219,15 +219,15 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
     def withParsedPaypalHook(paypalHookJson: JsValue)(block: PaypalHook => Future[Result]): Future[Result] = {
       bodyJson.validate[PaypalHook] match {
         case JsSuccess(paypalHook, _) if validHook =>
-          info(s"Received and parsed paymentHook: ${paypalHook.paymentId} for session id: ${request.sessionId}, platform: ${request.platform}.")
+          info(s"Received and parsed paymentHook: ${paypalHook.paymentId} for session id: ${request.sessionIdFragment}, platform: ${request.platform}.")
           cloudWatchMetrics.logHookParsed(PaymentProvider.Paypal, request.platform)
           block(paypalHook)
         case JsError(err) =>
-          error(s"Unable to parse Json for session id: ${request.sessionId}, platform: ${request.sessionId}.\n\t parsing errors: $err")
+          error(s"Unable to parse Json for session id: ${request.sessionIdFragment}, platform: ${request.sessionIdFragment}.\n\t parsing errors: $err")
           cloudWatchMetrics.logHookParseError(PaymentProvider.Paypal, request.platform)
           Future.successful(InternalServerError("Unable to parse json payload"))
         case _ =>
-          error(s"A paypal webhook request wasn't valid. Session id: ${request.sessionId}. Platform: ${request.platform}.\n\tRequest is: $request, headers: ${request.headers.toSimpleMap},body: $bodyText")
+          error(s"A paypal webhook request wasn't valid. Session id: ${request.sessionIdFragment}. Platform: ${request.platform}.\n\tRequest is: $request, headers: ${request.headers.toSimpleMap},body: $bodyText")
           cloudWatchMetrics.logHookInvalidRequest(PaymentProvider.Paypal, request.platform)
           Future.successful(Forbidden("Request isn't signed by Paypal"))
       }
@@ -236,12 +236,12 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
     withParsedPaypalHook(bodyJson) { paypalHook =>
       paypalService.processPaymentHook(paypalHook).value.map {
         case Right(_) => {
-          info(s"Paypal hook: ${paypalHook.paymentId} processed successfully for session id: ${request.sessionId}, platform: ${request.platform}.")
+          info(s"Paypal hook: ${paypalHook.paymentId} processed successfully for session id: ${request.sessionIdFragment}, platform: ${request.platform}.")
           cloudWatchMetrics.logHookProcessed(PaymentProvider.Paypal, request.platform)
           Ok
         }
         case Left(err) => {
-          error(s"Paypal hook: ${paypalHook.paymentId} processing error. Session id: ${request.sessionId}, platform: ${request.platform}. \n\t error: $err")
+          error(s"Paypal hook: ${paypalHook.paymentId} processing error. Session id: ${request.sessionIdFragment}, platform: ${request.platform}. \n\t error: $err")
           cloudWatchMetrics.logHookProcessError(PaymentProvider.Paypal, request.platform)
           InternalServerError
         }

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -45,7 +45,7 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
 
     val paypalService = paymentServices.paypalServiceFor(request)
 
-    info(s"Attempting paypal payment for id: ${request.id}")
+    info(s"Attempting paypal payment for id: ${request.sessionId}")
     cloudWatchMetrics.logPaymentAttempt(PaymentProvider.Paypal, request.platform)
 
     def storeMetaData(payment: Payment) =
@@ -64,7 +64,7 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
       )
 
     def notOkResult(message: String): Result = {
-      error(s"Error executing PayPal payment for request id: ${request.id} \n\t error message: $message")
+      error(s"Error executing PayPal payment for session id: ${request.sessionId} \n\t error message: $message")
       cloudWatchMetrics.logPaymentFailure(PaymentProvider.Paypal, request.platform)
       render {
         case Accepts.Json() => BadRequest(JsNull)
@@ -82,7 +82,7 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
           val session = List("email" -> email, PaymentProvider.sessionKey -> PaymentProvider.Paypal.entryName) ++ amount.map("amount" -> _.show)
           redirectWithCampaignCodes(routes.Contributions.postPayment(countryGroup).url).addingToSession(session: _ *)
       }
-      info(s"Paypal payment from platform: ${request.platform} is successful. Request id: ${request.id}.")
+      info(s"Paypal payment from platform: ${request.platform} is successful. Session id: ${request.sessionId}.")
       cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Paypal, request.platform)
       response.setCookie[ContribTimestampCookieAttributes](payment.getCreateTime)
     }
@@ -173,7 +173,7 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
 
   def authorize = checkToken {
     NoCacheAction.async(parse.json[AuthRequest]) { implicit request =>
-      info(s"Attempting to obtain paypal auth response. Request id: ${request.id}. Platform: ${request.platform}.")
+      info(s"Attempting to obtain paypal auth response. Session id: ${request.sessionId}. Platform: ${request.platform}.")
       cloudWatchMetrics.logPaymentAuthAttempt(PaymentProvider.Paypal, request.platform)
       val authRequest = request.body
       val amount = capAmount(authRequest.amount, authRequest.countryGroup.currency)
@@ -193,12 +193,12 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
 
       payment.subflatMap(AuthResponse.fromPayment).fold(
         err => {
-          error(s"Error getting PayPal auth response for request id: ${request.id}, platform: ${request.platform}.\n\t error message: $err")
+          error(s"Error getting PayPal auth response for session id: ${request.sessionId}, platform: ${request.platform}.\n\t error message: $err")
           cloudWatchMetrics.logPaymentAuthFailure(PaymentProvider.Paypal, request.platform)
           InternalServerError("Error getting PayPal auth url")
         },
         authResponse => {
-          info(s"Paypal payment auth response successfully obtained for request id: ${request.id}, platform: ${request.platform}.")
+          info(s"Paypal payment auth response successfully obtained for session id: ${request.sessionId}, platform: ${request.platform}.")
           cloudWatchMetrics.logPaymentAuthSuccess(PaymentProvider.Paypal, request.platform)
           Ok(Json.toJson(authResponse))
         }
@@ -210,7 +210,7 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
     val bodyText = request.body
     val bodyJson = Json.parse(request.body)
 
-    info(s"Paypal hook attempt made for request id: ${request.id}, Platform: ${request.platform}")
+    info(s"Paypal hook attempt made for session id: ${request.sessionId}, Platform: ${request.platform}")
     cloudWatchMetrics.logHookAttempt(PaymentProvider.Paypal, request.platform)
 
     val paypalService = paymentServices.paypalServiceFor(request)
@@ -219,15 +219,15 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
     def withParsedPaypalHook(paypalHookJson: JsValue)(block: PaypalHook => Future[Result]): Future[Result] = {
       bodyJson.validate[PaypalHook] match {
         case JsSuccess(paypalHook, _) if validHook =>
-          info(s"Received and parsed paymentHook: ${paypalHook.paymentId} for request id: ${request.id}, platform: ${request.platform}.")
+          info(s"Received and parsed paymentHook: ${paypalHook.paymentId} for session id: ${request.sessionId}, platform: ${request.platform}.")
           cloudWatchMetrics.logHookParsed(PaymentProvider.Paypal, request.platform)
           block(paypalHook)
         case JsError(err) =>
-          error(s"Unable to parse Json for request id: ${request.id}, platform: ${request.platform}.\n\t parsing errors: $err")
+          error(s"Unable to parse Json for session id: ${request.sessionId}, platform: ${request.sessionId}.\n\t parsing errors: $err")
           cloudWatchMetrics.logHookParseError(PaymentProvider.Paypal, request.platform)
           Future.successful(InternalServerError("Unable to parse json payload"))
         case _ =>
-          error(s"A paypal webhook request wasn't valid. Request id: ${request.id}. Platform: ${request.platform}.\n\tRequest is: $request, headers: ${request.headers.toSimpleMap},body: $bodyText")
+          error(s"A paypal webhook request wasn't valid. Session id: ${request.sessionId}. Platform: ${request.platform}.\n\tRequest is: $request, headers: ${request.headers.toSimpleMap},body: $bodyText")
           cloudWatchMetrics.logHookInvalidRequest(PaymentProvider.Paypal, request.platform)
           Future.successful(Forbidden("Request isn't signed by Paypal"))
       }
@@ -236,12 +236,12 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
     withParsedPaypalHook(bodyJson) { paypalHook =>
       paypalService.processPaymentHook(paypalHook).value.map {
         case Right(_) => {
-          info(s"Paypal hook: ${paypalHook.paymentId} processed successfully for request id: ${request.id}, platform: ${request.platform}.")
+          info(s"Paypal hook: ${paypalHook.paymentId} processed successfully for session id: ${request.sessionId}, platform: ${request.platform}.")
           cloudWatchMetrics.logHookProcessed(PaymentProvider.Paypal, request.platform)
           Ok
         }
         case Left(err) => {
-          error(s"Paypal hook: ${paypalHook.paymentId} processing error. Request id: ${request.id}, platform: ${request.platform}. \n\t error: $err")
+          error(s"Paypal hook: ${paypalHook.paymentId} processing error. Session id: ${request.sessionId}, platform: ${request.platform}. \n\t error: $err")
           cloudWatchMetrics.logHookProcessError(PaymentProvider.Paypal, request.platform)
           InternalServerError
         }

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -7,6 +7,7 @@ import actions.CommonActions._
 import cats.data.EitherT
 import cats.syntax.show._
 import com.gu.i18n.CountryGroup._
+import com.gu.i18n.Currency.USD
 import com.gu.i18n.{AUD, EUR, USD}
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Charge
@@ -37,7 +38,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
   // THIS ENDPOINT IS USED BY BOTH THE FRONTEND AND THE MOBILE-APP
   def pay = (NoCacheAction andThen MobileSupportAction andThen ABTestAction)
     .async(BodyParsers.jsonOrMultipart(ContributionRequest.contributionForm)) { implicit request =>
-    info(s"A Stripe payment is being attempted with request id: ${request.id}, from platform: ${request.platform}.")
+    info(s"A Stripe payment is being attempted with session id: ${request.sessionId}, from platform: ${request.platform}.")
     cloudWatchMetrics.logPaymentAttempt(PaymentProvider.Stripe, request.platform)
 
     val form = request.body
@@ -78,7 +79,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
     val contributionAmount = ContributionAmount(BigDecimal(amount, 2), form.currency)
 
     def thankYouUri = if (request.isAndroid) {
-      info(s"Payment successful for request ${request.id} - redirected to external platform for thank you page. platform is: ${request.platform}.")
+      info(s"Payment successful for request ${request.sessionId} - redirected to external platform for thank you page. platform is: ${request.platform}.")
       cloudWatchMetrics.logPaymentSuccessRedirected(PaymentProvider.Stripe, request.platform)
       mobileRedirectUrl(contributionAmount)
     } else {
@@ -129,7 +130,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
     }
 
     createCharge.map { charge =>
-      info(s"Stripe payment successful for request id: ${request.id}, from platform ${request.platform}")
+      info(s"Stripe payment successful for session id: ${request.sessionId}, from platform ${request.platform}")
       cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Stripe, request.platform)
       val metadata = createMetaData(charge)
       storeMetaData(metadata) // fire and forget. If it fails we don't want to stop the user
@@ -142,7 +143,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
         .withHeaders(corsHeaders(request): _*)
     }.recover {
       case e: Stripe.Error => {
-        warn(s"Payment failed for request id: ${request.id}, from platform: ${request.platform}, \n\t with code: ${e.decline_code} \n\t and message: ${e.message}.")
+        warn(s"Payment failed for session id: ${request.sessionId}, from platform: ${request.platform}, \n\t with code: ${e.decline_code} \n\t and message: ${e.message}.")
         cloudWatchMetrics.logPaymentFailure(PaymentProvider.Stripe, request.platform)
         BadRequest(Json.toJson(e)).withHeaders(corsHeaders(request): _*)
       }
@@ -172,11 +173,11 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
       def withParsedStripeHook(stripeHookJson: JsValue)(block: StripeHook => Future[Result]): Future[Result] = {
         stripeHookJson.validate[StripeHook] match {
           case JsError(err) =>
-            error(s"Unable to parse the stripe hook for request id: ${request.id}, from platform: ${request.platform}. \n\tFailed with message: $err")
+            error(s"Unable to parse the stripe hook for session id: ${request.sessionId}, from platform: ${request.platform}. \n\tFailed with message: $err")
             cloudWatchMetrics.logHookParseError(PaymentProvider.Stripe, request.platform)
             Future.successful(BadRequest("Invalid Json"))
           case JsSuccess(stripeHook, _) =>
-            info(s"Processing a stripe hook for request id: ${request.id}, from platform: ${request.platform}. Stripe Hook id is: ${stripeHook.eventId}")
+            info(s"Processing a stripe hook for session id: ${request.sessionId}, from platform: ${request.platform}. Stripe Hook id is: ${stripeHook.eventId}")
             cloudWatchMetrics.logHookParsed(PaymentProvider.Stripe, request.platform)
             block(stripeHook)
         }
@@ -187,12 +188,12 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
         stripeService.processPaymentHook(stripeHook)
           .value.map {
           case Right(_) => {
-            info(s"Stripe hook: ${stripeHook.paymentId} processed successfully for request id: ${request.id}, from platform ${request.platform}.")
+            info(s"Stripe hook: ${stripeHook.paymentId} processed successfully for session id: ${request.sessionId}, from platform ${request.platform}.")
             cloudWatchMetrics.logHookProcessed(PaymentProvider.Stripe, request.platform)
             Ok
           }
           case Left(err) => {
-            error(s"Stripe hook: ${stripeHook.paymentId} processing error for request id: ${request.id}, from platform: ${request.platform} \n\t error: $err")
+            error(s"Stripe hook: ${stripeHook.paymentId} processing error for session id: ${request.sessionId}, from platform: ${request.platform} \n\t error: $err")
             cloudWatchMetrics.logHookProcessError(PaymentProvider.Stripe, request.platform)
             InternalServerError
           }

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -7,7 +7,6 @@ import actions.CommonActions._
 import cats.data.EitherT
 import cats.syntax.show._
 import com.gu.i18n.CountryGroup._
-import com.gu.i18n.Currency.USD
 import com.gu.i18n.{AUD, EUR, USD}
 import com.gu.stripe.Stripe
 import com.gu.stripe.Stripe.Charge
@@ -38,7 +37,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
   // THIS ENDPOINT IS USED BY BOTH THE FRONTEND AND THE MOBILE-APP
   def pay = (NoCacheAction andThen MobileSupportAction andThen ABTestAction)
     .async(BodyParsers.jsonOrMultipart(ContributionRequest.contributionForm)) { implicit request =>
-    info(s"A Stripe payment is being attempted with session id: ${request.sessionId}, from platform: ${request.platform}.")
+    info(s"A Stripe payment is being attempted with session id: ${request.sessionIdFragment}, from platform: ${request.platform}.")
     cloudWatchMetrics.logPaymentAttempt(PaymentProvider.Stripe, request.platform)
 
     val form = request.body
@@ -79,7 +78,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
     val contributionAmount = ContributionAmount(BigDecimal(amount, 2), form.currency)
 
     def thankYouUri = if (request.isAndroid) {
-      info(s"Payment successful for request ${request.sessionId} - redirected to external platform for thank you page. platform is: ${request.platform}.")
+      info(s"Payment successful for request ${request.sessionIdFragment} - redirected to external platform for thank you page. platform is: ${request.platform}.")
       cloudWatchMetrics.logPaymentSuccessRedirected(PaymentProvider.Stripe, request.platform)
       mobileRedirectUrl(contributionAmount)
     } else {
@@ -130,7 +129,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
     }
 
     createCharge.map { charge =>
-      info(s"Stripe payment successful for session id: ${request.sessionId}, from platform ${request.platform}")
+      info(s"Stripe payment successful for session id: ${request.sessionIdFragment}, from platform ${request.platform}")
       cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Stripe, request.platform)
       val metadata = createMetaData(charge)
       storeMetaData(metadata) // fire and forget. If it fails we don't want to stop the user
@@ -143,7 +142,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
         .withHeaders(corsHeaders(request): _*)
     }.recover {
       case e: Stripe.Error => {
-        warn(s"Payment failed for session id: ${request.sessionId}, from platform: ${request.platform}, \n\t with code: ${e.decline_code} \n\t and message: ${e.message}.")
+        warn(s"Payment failed for session id: ${request.sessionIdFragment}, from platform: ${request.platform}, \n\t with code: ${e.decline_code} \n\t and message: ${e.message}.")
         cloudWatchMetrics.logPaymentFailure(PaymentProvider.Stripe, request.platform)
         BadRequest(Json.toJson(e)).withHeaders(corsHeaders(request): _*)
       }
@@ -173,11 +172,11 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
       def withParsedStripeHook(stripeHookJson: JsValue)(block: StripeHook => Future[Result]): Future[Result] = {
         stripeHookJson.validate[StripeHook] match {
           case JsError(err) =>
-            error(s"Unable to parse the stripe hook for session id: ${request.sessionId}, from platform: ${request.platform}. \n\tFailed with message: $err")
+            error(s"Unable to parse the stripe hook for session id: ${request.sessionIdFragment}, from platform: ${request.platform}. \n\tFailed with message: $err")
             cloudWatchMetrics.logHookParseError(PaymentProvider.Stripe, request.platform)
             Future.successful(BadRequest("Invalid Json"))
           case JsSuccess(stripeHook, _) =>
-            info(s"Processing a stripe hook for session id: ${request.sessionId}, from platform: ${request.platform}. Stripe Hook id is: ${stripeHook.eventId}")
+            info(s"Processing a stripe hook for session id: ${request.sessionIdFragment}, from platform: ${request.platform}. Stripe Hook id is: ${stripeHook.eventId}")
             cloudWatchMetrics.logHookParsed(PaymentProvider.Stripe, request.platform)
             block(stripeHook)
         }
@@ -188,12 +187,12 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
         stripeService.processPaymentHook(stripeHook)
           .value.map {
           case Right(_) => {
-            info(s"Stripe hook: ${stripeHook.paymentId} processed successfully for session id: ${request.sessionId}, from platform ${request.platform}.")
+            info(s"Stripe hook: ${stripeHook.paymentId} processed successfully for session id: ${request.sessionIdFragment}, from platform ${request.platform}.")
             cloudWatchMetrics.logHookProcessed(PaymentProvider.Stripe, request.platform)
             Ok
           }
           case Left(err) => {
-            error(s"Stripe hook: ${stripeHook.paymentId} processing error for session id: ${request.sessionId}, from platform: ${request.platform} \n\t error: $err")
+            error(s"Stripe hook: ${stripeHook.paymentId} processing error for session id: ${request.sessionIdFragment}, from platform: ${request.platform} \n\t error: $err")
             cloudWatchMetrics.logHookProcessError(PaymentProvider.Stripe, request.platform)
             InternalServerError
           }


### PR DESCRIPTION
This updates the "request id" field in logs to instead use a fragment of the csrf-token cookie.
This is because the request id changes during a payment for a user making it useless for debugging.
This cookie fragment is consistent through the entire payment flow for a user, so its easier to tell where something has gone wrong when debugging.



Have you gone through the contributions flow for all test variants ?
yes