### PR TITLE
Change Product CONTRIBUTION enum to ONE_OFF_CONTRIBUTION

### DIFF
--- a/app/services/OphanService.scala
+++ b/app/services/OphanService.scala
@@ -48,7 +48,7 @@ object PaymentFrequency extends Enum[PaymentFrequency] {
 }
 
 trait Product {
-  val stringValue = "CONTRIBUTION"
+  val stringValue = "ONE_OFF_CONTRIBUTION"
 }
 
 case object Contribution extends Product

--- a/test/services/OphanServiceSpec.scala
+++ b/test/services/OphanServiceSpec.scala
@@ -74,7 +74,7 @@ class OphanServiceSpec(environment: Environment) extends WordSpec with MustMatch
 
       val params = ophanEvent.toParams
       val url = ophanService.endpointUrl("a.gif", Seq(params:_*)).toString
-      url mustBe """https://contribute.thegulocal.com/testophan/a.gif?viewId=123&browserId=browserId&product=CONTRIBUTION&currency=GBP&paymentFrequency=ONE_OFF&amount=10.12&visitId=Some%28visit%29&amountInGBP=10.12&paymentProvider=STRIPE&campaignCode=woot,poot&abTests=%7B%22test%22%3A%7B%22variantName%22%3A%22control%22%7D%7D&countryCode=US&referrerPageViewId=refpivd&referrerUrl=refurl"""
+      url mustBe """https://contribute.thegulocal.com/testophan/a.gif?viewId=123&browserId=browserId&product=ONE_OFF_CONTRIBUTION&currency=GBP&amount=10.12&visitId=Some%28visit%29&amountInGBP=10.12&paymentProvider=STRIPE&campaignCode=woot,poot&abTests=%7B%22test%22%3A%7B%22variantName%22%3A%22control%22%7D%7D&countryCode=US&referrerPageViewId=refpivd&referrerUrl=refurl"""
 
     }
   }


### PR DESCRIPTION
As part of the Component event work currently taking place (https://github.com/guardian/ophan/pull/2344), it was decided that, rather than use `CONTRIBUTION` as an enum and differentiate one off and recurring contributions with another enum (`PAYMENT_FREQUENCY`), we should give `ONE_OFF_CONTRIBUTIONS` and `RECURRING_CONTRIBUTIONS` their own enumerated  `Product` names. It is, therefore, necessary to update Contributions Frontend to use the new naming. 

@guardian/contributions 






Have you gone through the contributions flow for all test variants ?
