### PR TITLE
Cross origin cookies

### DIFF
--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -157,7 +157,8 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
     allowedOrigin.toList.flatMap { origin =>
       List(
         "Access-Control-Allow-Origin" -> origin,
-        "Access-Control-Allow-Headers" -> "Origin, Content-Type, Accept"
+        "Access-Control-Allow-Headers" -> "Origin, Content-Type, Accept",
+        "Access-Control-Allow-Credentials" -> "true"
       )
     }
   }

--- a/app/cookies/ContribTimestampCookieAttributes.scala
+++ b/app/cookies/ContribTimestampCookieAttributes.scala
@@ -15,7 +15,7 @@ trait ContribTimestampCookieAttributes extends CookieAttributes {
    * If in production, the guardian domain is used, so that the cookie will be accessible from
    * e.g. theguardian.com, contribute.theguardian.com
    */
-  override val domain: Option[String] = if (Config.stageProd) Some(Config.guardianDomain) else Config.domain
+  override val domain: Option[String] = if (Config.stageProd) Some(Config.guardianDomain) else Config.domain.map(_.stripPrefix("contribute"))
 }
 
 object ContribTimestampCookieAttributes {


### PR DESCRIPTION
Add Access-Control-Allow-Credentials header for support-frontend requests so that gu.contributions.contrib-timestamp cookie can be set by contribute.theguardian.com for requests from support.theguardian.com

This PR also sets the correct domain for cookies in dev/code to make testing easier