### PR TITLE
Paypal mobile preparation

### DIFF
--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -6,24 +6,19 @@ import cats.syntax.show._
 import cookies.ContribTimestampCookieAttributes
 import cookies.syntax._
 import com.gu.i18n.{CountryGroup, Currency}
-import com.netaporter.uri.Uri
 import com.paypal.api.payments.Payment
+import controllers.forms.{AuthRequest, AuthResponse}
 import models._
 import monitoring._
-import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.PaymentServices
 import play.api.data.Form
 import utils.MaxAmount
 import play.api.libs.json._
-import play.api.libs.json.Reads._
-import play.api.libs.functional.syntax._
 import play.api.data.Forms._
-import play.api.http.Writeable
 import play.filters.csrf.CSRFCheck
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
 
 class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, cloudWatchMetrics: CloudWatchMetrics)(implicit ec: ExecutionContext)
   extends Controller with Redirect with TagAwareLogger with LoggingTagsProvider {
@@ -90,83 +85,6 @@ class PaypalController(paymentServices: PaymentServices, checkToken: CSRFCheck, 
     paypalService.executePayment(paymentId, payerId)
       .map { payment => storeMetaData(payment); payment }
       .fold(notOkResult, okResult)
-  }
-
-  case class AuthRequest private (
-    countryGroup: CountryGroup,
-    amount: BigDecimal,
-    cmp: Option[String],
-    intCmp: Option[String],
-    refererPageviewId: Option[String],
-    refererUrl: Option[String],
-    ophanPageviewId: Option[String],
-    ophanBrowserId: Option[String],
-    ophanVisitId: Option[String]
-  )
-
-  object AuthRequest {
-    /**
-      * We need to ensure there's no fragment in the URL here, as PayPal appends some query parameters to the end of it,
-      * which will be removed by the browser (due to the URL stripping rules) in its requests.
-      *
-      * See: https://www.w3.org/TR/referrer-policy/#strip-url
-      *
-      */
-    def withSafeRefererUrl(
-                            countryGroup: CountryGroup,
-                            amount: BigDecimal,
-                            cmp: Option[String],
-                            intCmp: Option[String],
-                            refererPageviewId: Option[String],
-                            refererUrl: Option[String],
-                            ophanPageviewId: Option[String],
-                            ophanBrowserId: Option[String],
-                            ophanVisitId: Option[String]
-                          ): AuthRequest = {
-      val safeRefererUrl = refererUrl.flatMap(url => Try(Uri.parse(url).copy(fragment = None).toString).toOption)
-
-      new AuthRequest(countryGroup, amount, cmp, intCmp, refererPageviewId, safeRefererUrl, ophanPageviewId, ophanBrowserId, ophanVisitId)
-    }
-
-
-    implicit val authRequestReads: Reads[AuthRequest] = (
-      (__ \ "countryGroup").read[CountryGroup] and
-        (__ \ "amount").read(min[BigDecimal](1)) and
-        (__ \ "cmp").readNullable[String] and
-        (__ \ "intCmp").readNullable[String] and
-        (__ \ "refererPageviewId").readNullable[String] and
-        (__ \ "refererUrl").readNullable[String] and
-        (__ \ "ophanPageviewId").readNullable[String] and
-        (__ \ "ophanBrowserId").readNullable[String] and
-        (__ \ "ophanVisitId").readNullable[String]
-      ) (AuthRequest.withSafeRefererUrl _)
-  }
-
-  case class AuthResponse(approvalUrl: Uri, paymentId: String)
-
-  object AuthResponse {
-    import cats.syntax.either._
-    import scala.collection.JavaConverters._
-
-    def fromPayment(payment: Payment): Either[String, AuthResponse] = Either.fromOption(for {
-        links <- Option(payment.getLinks)
-        approvalLinks <- links.asScala.find(_.getRel.equalsIgnoreCase("approval_url"))
-        approvalUrl <- Option(approvalLinks.getHref)
-        paymentId <- Option(payment.getId)
-      } yield AuthResponse(Uri.parse(approvalUrl), paymentId), "Unable to parse payment")
-  }
-
-  implicit val UriWrites = new Writes[Uri] {
-    override def writes(uri: Uri): JsValue = JsString(uri.toString)
-  }
-
-  implicit val AuthResponseWrites = Json.writes[AuthResponse]
-
-  implicit val CountryGroupReads = new Reads[CountryGroup] {
-    override def reads(json: JsValue): JsResult[CountryGroup] = json match {
-      case JsString(id) => CountryGroup.byId(id).map(JsSuccess(_)).getOrElse(JsError("invalid CountryGroup id"))
-      case _ => JsError("invalid value for country group")
-    }
   }
 
   private def capAmount(amount: BigDecimal, currency: Currency): BigDecimal = amount min MaxAmount.forCurrency(currency)

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -7,7 +7,7 @@ import cookies.ContribTimestampCookieAttributes
 import cookies.syntax._
 import com.gu.i18n.{CountryGroup, Currency}
 import com.paypal.api.payments.Payment
-import controllers.forms.{AuthRequest, AuthResponse}
+import controllers.httpmodels.{AuthRequest, AuthResponse}
 import models._
 import monitoring._
 import play.api.mvc._

--- a/app/controllers/forms/AuthRequest.scala
+++ b/app/controllers/forms/AuthRequest.scala
@@ -1,0 +1,81 @@
+package controllers.forms
+
+import com.gu.i18n.CountryGroup
+import com.netaporter.uri.Uri
+import com.paypal.api.payments.Payment
+import play.api.libs.json.Reads.min
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import utils.JsonUtils._
+
+import scala.util.Try
+
+
+case class AuthRequest private (
+  countryGroup: CountryGroup,
+  amount: BigDecimal,
+  cmp: Option[String],
+  intCmp: Option[String],
+  refererPageviewId: Option[String],
+  refererUrl: Option[String],
+  ophanPageviewId: Option[String],
+  ophanBrowserId: Option[String],
+  ophanVisitId: Option[String]
+)
+
+object AuthRequest {
+  /**
+    * We need to ensure there's no fragment in the URL here, as PayPal appends some query parameters to the end of it,
+    * which will be removed by the browser (due to the URL stripping rules) in its requests.
+    *
+    * See: https://www.w3.org/TR/referrer-policy/#strip-url
+    *
+    */
+  def withSafeRefererUrl(
+    countryGroup: CountryGroup,
+    amount: BigDecimal,
+    cmp: Option[String],
+    intCmp: Option[String],
+    refererPageviewId: Option[String],
+    refererUrl: Option[String],
+    ophanPageviewId: Option[String],
+    ophanBrowserId: Option[String],
+    ophanVisitId: Option[String]
+  ): AuthRequest = {
+    val safeRefererUrl = refererUrl.flatMap(url => Try(Uri.parse(url).copy(fragment = None).toString).toOption)
+
+    new AuthRequest(countryGroup, amount, cmp, intCmp, refererPageviewId, safeRefererUrl, ophanPageviewId, ophanBrowserId, ophanVisitId)
+  }
+
+  implicit val authRequestReads: Reads[AuthRequest] = (
+    (__ \ "countryGroup").read[CountryGroup] and
+      (__ \ "amount").read(min[BigDecimal](1)) and
+      (__ \ "cmp").readNullable[String] and
+      (__ \ "intCmp").readNullable[String] and
+      (__ \ "refererPageviewId").readNullable[String] and
+      (__ \ "refererUrl").readNullable[String] and
+      (__ \ "ophanPageviewId").readNullable[String] and
+      (__ \ "ophanBrowserId").readNullable[String] and
+      (__ \ "ophanVisitId").readNullable[String]
+    ) (AuthRequest.withSafeRefererUrl _)
+}
+
+case class AuthResponse(approvalUrl: Uri, paymentId: String)
+
+object AuthResponse {
+  import cats.syntax.either._
+  import scala.collection.JavaConverters._
+
+  def fromPayment(payment: Payment): Either[String, AuthResponse] = Either.fromOption(for {
+    links <- Option(payment.getLinks)
+    approvalLinks <- links.asScala.find(_.getRel.equalsIgnoreCase("approval_url"))
+    approvalUrl <- Option(approvalLinks.getHref)
+    paymentId <- Option(payment.getId)
+  } yield AuthResponse(Uri.parse(approvalUrl), paymentId), "Unable to parse payment")
+
+  implicit val uriWrites = new Writes[Uri] {
+    override def writes(uri: Uri): JsValue = JsString(uri.toString)
+  }
+
+  implicit val authResponseWrites: Writes[AuthResponse] = Json.writes[AuthResponse]
+}

--- a/app/controllers/httpmodels/AuthRequest.scala
+++ b/app/controllers/httpmodels/AuthRequest.scala
@@ -1,11 +1,11 @@
-package controllers.forms
+package controllers.httpmodels
 
 import com.gu.i18n.CountryGroup
 import com.netaporter.uri.Uri
 import com.paypal.api.payments.Payment
+import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads.min
 import play.api.libs.json._
-import play.api.libs.functional.syntax._
 import utils.JsonUtils._
 
 import scala.util.Try
@@ -64,6 +64,7 @@ case class AuthResponse(approvalUrl: Uri, paymentId: String)
 
 object AuthResponse {
   import cats.syntax.either._
+
   import scala.collection.JavaConverters._
 
   def fromPayment(payment: Payment): Either[String, AuthResponse] = Either.fromOption(for {

--- a/app/utils/JsonUtils.scala
+++ b/app/utils/JsonUtils.scala
@@ -1,0 +1,13 @@
+package utils
+
+import com.gu.i18n.CountryGroup
+import play.api.libs.json._
+
+object JsonUtils {
+  implicit val countryGroupReads = new Reads[CountryGroup] {
+    override def reads(json: JsValue): JsResult[CountryGroup] = json match {
+      case JsString(id) => CountryGroup.byId(id).map(JsSuccess(_)).getOrElse(JsError("invalid CountryGroup id"))
+      case _ => JsError("invalid value for country group")
+    }
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,5 +1,5 @@
 play.application.loader = "wiring.AppLoader"
-
+play.http.secret.key="a-very-secret-dev-key"
 play.http.session.secure=true
 
 play.http.errorHandler = "monitoring.ErrorHandler"

--- a/test/controllers/PaypalControllerSpec.scala
+++ b/test/controllers/PaypalControllerSpec.scala
@@ -63,7 +63,7 @@ class PaypalControllerFixture(implicit ec: ExecutionContext) extends MockitoSuga
 
   val controller: PaypalController = new PaypalController(mockPaymentServices, mockCsrfCheck, mockCloudwatchMetrics)
 
-  def storeMetaDataCalled(times: Int): Unit = {
+  def numberOfCallsToStoreMetaDataMustBe(times: Int): Unit = {
     def captor[A <: AnyRef](implicit classTag: ClassTag[A]): A =
       ArgumentCaptor.forClass[A](classTag.runtimeClass.asInstanceOf[Class[A]]).capture()
 
@@ -122,7 +122,7 @@ class PaypalControllerSpec extends PlaySpec
       status(result).mustBe(303)
       redirectLocation(result).mustBe(Some("/uk/post-payment"))
 
-      fixture.storeMetaDataCalled(1)
+      fixture.numberOfCallsToStoreMetaDataMustBe(1)
     }
 
     "generate correct redirect URL for unsuccessful PayPal payments" in {
@@ -136,7 +136,7 @@ class PaypalControllerSpec extends PlaySpec
       status(result).mustBe(303)
       redirectLocation(result).mustBe(Some("/uk?error_code=PaypalError"))
 
-      fixture.storeMetaDataCalled(0)
+      fixture.numberOfCallsToStoreMetaDataMustBe(0)
     }
   }
 }

--- a/test/controllers/PaypalControllerSpec.scala
+++ b/test/controllers/PaypalControllerSpec.scala
@@ -1,12 +1,13 @@
 package controllers
 
+import abtests.Allocation
 import cats.data.EitherT
 import com.gu.i18n.{CountryGroup, GBP}
 import com.paypal.api.payments.Payment
 import fixtures.TestApplicationFactory
-import models.ContributionAmount
+import models.{ContributionAmount, IdentityId, SavedContributionData}
 import monitoring.{CloudWatchMetrics, LoggingTags}
-import org.mockito.{Matchers, Mockito}
+import org.mockito.{ArgumentCaptor, Matchers, Mockito}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play._
 import play.api.http.{HeaderNames, Status}
@@ -14,19 +15,24 @@ import play.api.mvc._
 import play.api.test._
 import play.filters.csrf.CSRFCheck
 import services.{PaymentServices, PaypalService}
+import cats.instances.future._
+import org.mockito.internal.verification.VerificationModeFactory
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
 
-trait PaypalControllerMocks extends MockitoSugar {
+class PaypalControllerFixture(implicit ec: ExecutionContext) extends MockitoSugar {
+
   val mockPaymentServices: PaymentServices = mock[PaymentServices]
 
-  val mockPaypalService = mock[PaypalService]
+  val mockPaypalService: PaypalService = mock[PaypalService]
   val mockPaypalPayment: Payment = Mockito.mock[Payment](classOf[Payment], Mockito.RETURNS_DEEP_STUBS)
   val mockContributionAmount: ContributionAmount = ContributionAmount(10, GBP)
 
   val mockCsrfCheck: CSRFCheck = mock[CSRFCheck]
 
-  val mockCloudwatchMetrics = mock[CloudWatchMetrics]
+  val mockCloudwatchMetrics: CloudWatchMetrics = mock[CloudWatchMetrics]
 
   Mockito.when(mockPaymentServices.paypalServiceFor(Matchers.any[Request[_]]))
     .thenReturn(mockPaypalService)
@@ -39,10 +45,45 @@ trait PaypalControllerMocks extends MockitoSugar {
 
   Mockito.when(mockPaypalPayment.getPayer.getPayerInfo.getEmail)
     .thenReturn("a@b.com")
+
+  Mockito.when(mockPaypalService.storeMetaData(
+    paymentId = Matchers.any[String],
+    testAllocations = Matchers.any[Set[Allocation]],
+    cmp = Matchers.any[Option[String]],
+    intCmp = Matchers.any[Option[String]],
+    refererPageviewId = Matchers.any[Option[String]],
+    refererUrl = Matchers.any[Option[String]],
+    ophanPageviewId = Matchers.any[Option[String]],
+    ophanBrowserId = Matchers.any[Option[String]],
+    idUser = Matchers.any[Option[IdentityId]],
+    platform = Matchers.any[Option[String]],
+    ophanVisitId = Matchers.any[Option[String]]
+  )(Matchers.any[LoggingTags]))
+    .thenReturn(EitherT.pure[Future, String, SavedContributionData](mock[SavedContributionData]))
+
+  val controller: PaypalController = new PaypalController(mockPaymentServices, mockCsrfCheck, mockCloudwatchMetrics)
+
+  def storeMetaDataCalled(times: Int): Unit = {
+    def captor[A <: AnyRef](implicit classTag: ClassTag[A]): A =
+      ArgumentCaptor.forClass[A](classTag.runtimeClass.asInstanceOf[Class[A]]).capture()
+
+    Mockito.verify(mockPaypalService, VerificationModeFactory.times(times)).storeMetaData(
+      captor[String],
+      captor[Set[Allocation]],
+      captor[Option[String]],
+      captor[Option[String]],
+      captor[Option[String]],
+      captor[Option[String]],
+      captor[Option[String]],
+      captor[Option[String]],
+      captor[Option[IdentityId]],
+      captor[Option[String]],
+      captor[Option[String]]
+    )(captor[LoggingTags])
+  }
 }
 
 class PaypalControllerSpec extends PlaySpec
-  with PaypalControllerMocks
   with HeaderNames
   with Status
   with ResultExtractors
@@ -50,14 +91,11 @@ class PaypalControllerSpec extends PlaySpec
   with TestApplicationFactory
   with BaseOneAppPerSuite {
 
-  import cats.instances.future._
-
   implicit val executionContext: ExecutionContext = app.actorSystem.dispatcher
 
-  val controller: PaypalController = new PaypalController(mockPaymentServices, mockCsrfCheck, mockCloudwatchMetrics)
   val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/").withHeaders(("Accept", "text/html"))
 
-  def executePayment: Action[AnyContent] = controller.executePayment(
+  def executePayment(controller: PaypalController): Action[AnyContent] = controller.executePayment(
     countryGroup = CountryGroup.UK,
     paymentId = "test",
     token = "test",
@@ -74,23 +112,31 @@ class PaypalControllerSpec extends PlaySpec
   "Paypal Controller" should {
 
     "generate correct redirect URL for successful PayPal payments" in {
-      Mockito.when(mockPaypalService.executePayment(Matchers.anyString, Matchers.anyString)(Matchers.any[LoggingTags]))
-        .thenReturn(EitherT.right[Future, String, Payment](Future.successful(mockPaypalPayment)))
+      val fixture = new PaypalControllerFixture {
+        Mockito.when(mockPaypalService.executePayment(Matchers.anyString, Matchers.anyString)(Matchers.any[LoggingTags]))
+          .thenReturn(EitherT.pure[Future, String, Payment](mockPaypalPayment))
+      }
 
-      val result: Future[Result] = executePayment(fakeRequest)
+      val result: Future[Result] = executePayment(fixture.controller)(fakeRequest)
 
       status(result).mustBe(303)
       redirectLocation(result).mustBe(Some("/uk/post-payment"))
+
+      fixture.storeMetaDataCalled(1)
     }
 
     "generate correct redirect URL for unsuccessful PayPal payments" in {
-      Mockito.when(mockPaypalService.executePayment(Matchers.anyString, Matchers.anyString)(Matchers.any[LoggingTags]))
-        .thenReturn(EitherT.left[Future, String, Payment](Future.successful("Error")))
+      val fixture = new PaypalControllerFixture {
+        Mockito.when(mockPaypalService.executePayment(Matchers.anyString, Matchers.anyString)(Matchers.any[LoggingTags]))
+          .thenReturn(EitherT.left[Future, String, Payment](Future.successful("Error")))
+      }
 
-      val result: Future[Result] = executePayment(fakeRequest)
+      val result: Future[Result] = executePayment(fixture.controller)(fakeRequest)
 
       status(result).mustBe(303)
       redirectLocation(result).mustBe(Some("/uk?error_code=PaypalError"))
+
+      fixture.storeMetaDataCalled(0)
     }
   }
 }


### PR DESCRIPTION
I was about to create a PR for the paypal mobile support but it was about 400 lines of code.

400 being to big to be digestible, I split it in two:
 - refactor of the existing code base (the present PR)
 - support for mobile payments via paypal

This PR focuses on:
 - extracting models from the paypal controller file in order to remove noise, and store them separately
 - refactor the test to ensure we test that the metadata is stored

cc @guardian/contributions cc @mohammad-haque 