### PR TITLE
Remove ELB session stickiness

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -162,8 +162,6 @@
             InstancePort: 9000
             Protocol: HTTPS
             SSLCertificateId: !Ref ELBSSLCertificate
-            PolicyNames:
-              - CookieBasedPolicy
         SecurityGroups:
           - !Ref LoadBalancerSecurityGroup
         Subnets: !Ref Subnets


### PR DESCRIPTION
A minor update to the last PR (https://github.com/guardian/contributions-frontend/pull/298) to remove a reference to the policy.