### PR TITLE
Paypal support frontend redirect

### DIFF
--- a/app/configuration/CorsConfig.scala
+++ b/app/configuration/CorsConfig.scala
@@ -1,0 +1,12 @@
+package configuration
+
+import com.typesafe.config.Config
+import scala.collection.JavaConversions._
+
+case class CorsConfig(allowedOrigins: List[String])
+
+object CorsConfig {
+  def from(config: Config) = CorsConfig(
+    allowedOrigins = config.getStringList("allowedOrigins").toList
+  )
+}

--- a/app/configuration/SupportConfig.scala
+++ b/app/configuration/SupportConfig.scala
@@ -1,0 +1,11 @@
+package configuration
+
+import com.typesafe.config.Config
+
+case class SupportConfig(thankYouURL: String)
+
+object SupportConfig {
+  def from(config: Config) = SupportConfig(
+    thankYouURL = config.getString("thank-you-url")
+  )
+}

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -13,6 +13,7 @@ import com.gu.stripe.Stripe.Charge
 import com.gu.stripe.Stripe.Serializer._
 import com.gu.zuora.soap.models.Queries.PaymentMethod
 import com.typesafe.config.Config
+import configuration.CorsConfig
 import controllers.forms.ContributionRequest
 import cookies.ContribTimestampCookieAttributes
 import cookies.syntax._
@@ -27,7 +28,7 @@ import utils.MaxAmount
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class StripeController(paymentServices: PaymentServices, stripeConfig: Config, ophanService: OphanService, cloudWatchMetrics: CloudWatchMetrics)(implicit ec: ExecutionContext)
+class StripeController(paymentServices: PaymentServices, stripeConfig: Config, corsConfig: CorsConfig, ophanService: OphanService, cloudWatchMetrics: CloudWatchMetrics)(implicit ec: ExecutionContext)
   extends Controller with Redirect with TagAwareLogger with LoggingTagsProvider {
 
   def payOptions = CachedAction { request =>
@@ -149,11 +150,9 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, o
     }
   }
 
-  private val allowedOrigins = stripeConfig.getStringList("cors.allowedOrigins")
-
   private def corsHeaders(request: Request[_]) = {
     val origin = request.headers.get("origin")
-    val allowedOrigin = origin.filter(allowedOrigins.contains)
+    val allowedOrigin = origin.filter(corsConfig.allowedOrigins.contains)
     allowedOrigin.toList.flatMap { origin =>
       List(
         "Access-Control-Allow-Origin" -> origin,

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -19,6 +19,7 @@ import monitoring.LoggingTags
 import org.joda.time.DateTime
 import play.api.libs.json.Json
 
+import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.math.BigDecimal.RoundingMode
@@ -82,7 +83,8 @@ class PaypalService(
     refererUrl: Option[String],
     ophanPageviewId: Option[String],
     ophanBrowserId: Option[String],
-    ophanVisitId: Option[String]
+    ophanVisitId: Option[String],
+    supportRedirect: Option[Boolean] = Some(false)
   )(implicit tags: LoggingTags): EitherT[Future, String, Payment] = {
 
     val paymentToCreate = {
@@ -95,7 +97,8 @@ class PaypalService(
           ophanBrowserId.map(value => s"bid=$value"),
           refererPageviewId.map(value => s"refererPageviewId=$value"),
           refererUrl.map(value => s"refererUrl=$value"),
-          ophanVisitId.map(value => s"ophanVisitId=$value")
+          ophanVisitId.map(value => s"ophanVisitId=$value"),
+          supportRedirect.map(value => s"supportRedirect=$value")
         ).flatten match {
           case Nil => ""
           case params => params.mkString("?", "&", "")

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -18,7 +18,7 @@ import play.filters.gzip.GzipFilterComponents
 import play.filters.headers.{SecurityHeadersConfig, SecurityHeadersFilter}
 import services.{EmailService, IdentityService, OphanService, PaymentServices}
 import router.Routes
-import configuration.Config
+import configuration.{Config, CorsConfig, SupportConfig}
 import monitoring.{CloudWatch, CloudWatchMetrics}
 
 //Sometimes intellij deletes this -> (import router.Routes)
@@ -30,6 +30,8 @@ trait AppComponents extends PlayComponents with GzipFilterComponents {
 
   lazy val config = ConfigFactory.load()
   lazy val stripeConfig = config.getConfig("stripe")
+  lazy val corsConfig = CorsConfig.from(config.getConfig("cors"))
+  lazy val supportConfig = SupportConfig.from(config.getConfig("support-frontend"))
   private val idConfig = config.getConfig("identity")
 
   lazy val identityKeys = if (idConfig.getBoolean("production.keys")) new ProductionKeys else new PreProductionKeys
@@ -73,7 +75,7 @@ trait AppComponents extends PlayComponents with GzipFilterComponents {
   lazy val healthcheckController = wire[Healthcheck]
   lazy val assetController = wire[Assets]
   lazy val paypalController = wire[PaypalController]
-  lazy val stripeController = new StripeController(paymentServices, stripeConfig, ophanService, cloudWatchMetrics)
+  lazy val stripeController = new StripeController(paymentServices, stripeConfig, corsConfig, ophanService, cloudWatchMetrics)
   lazy val userController = wire[UserController]
   lazy val epicComponentsController = wire[EpicComponentsController]
 

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -16,12 +16,6 @@ stripe {
             public = "pk_test_35RZz9AAyqErQshL410RDZMs"
         }
     }
-
-    cors {
-        allowedOrigins = [
-            "https://support.thegulocal.com"
-        ]
-    }
 }
 paypal {
     default=TEST
@@ -30,7 +24,19 @@ paypal {
         baseReturnUrl="https://contribute.thegulocal.com"
         paypalWebhookId="some_wehbhook_id"
     }
+
 }
+
+cors {
+    allowedOrigins = [
+        "https://support.thegulocal.com"
+    ]
+}
+
+support-frontend {
+    thank-you-url = "https://support.thegulocal.com/oneoff-contributions/thankyou"
+}
+
 identity {
     api.url="https://idapi.code.dev-theguardian.com"
     production.keys=false

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -27,12 +27,12 @@ paypal {
 
 cors {
     allowedOrigins = [
-        "https://support.thegulocal.com"
+        "https://support.theguardian.com"
     ]
 }
 
 support-frontend {
-    thank-you-url = "https://support.thegulocal.com/oneoff-contributions/thankyou"
+    thank-you-url = "https://support.theguardian.com/oneoff-contributions/thankyou"
 }
 
 

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -19,18 +19,22 @@ stripe {
             public = "pk_live_auSwLB4KBzbN3JOUVHvKMe6f"
         }
     }
-
-    cors {
-        allowedOrigins = [
-            "https://support.theguardian.com",
-            "https://support.code.dev-theguardian.com"
-        ]
-    }
 }
 paypal {
     default=LIVE
     testing=TEST
 }
+
+cors {
+    allowedOrigins = [
+        "https://support.thegulocal.com"
+    ]
+}
+
+support-frontend {
+    thank-you-url = "https://support.thegulocal.com/oneoff-contributions/thankyou"
+}
+
 
 identity {
     api.url="https://idapi.theguardian.com"

--- a/conf/routes
+++ b/conf/routes
@@ -15,8 +15,9 @@ GET            /                                controllers.Contributions.contri
 GET            /home                            controllers.Contributions.contributeRedirect
 GET            /healthcheck                     controllers.Healthcheck.healthcheck
 POST           /paypal/auth                     controllers.PaypalController.authorize
+OPTIONS        /paypal/auth                     controllers.PaypalController.authorizeOptions
 
-GET            /paypal/:countryGroup/execute    controllers.PaypalController.executePayment(countryGroup: CountryGroup, paymentId, token, PayerID, CMP: Option[String], INTCMP: Option[String], refererPageviewId: Option[String], refererUrl: Option[String],pvid: Option[String], bid: Option[String], ophanVisitId: Option[String])
+GET            /paypal/:countryGroup/execute    controllers.PaypalController.executePayment(countryGroup: CountryGroup, paymentId, token, PayerID, CMP: Option[String], INTCMP: Option[String], refererPageviewId: Option[String], refererUrl: Option[String],pvid: Option[String], bid: Option[String], ophanVisitId: Option[String], supportRedirect: Option[Boolean])
 POST           /paypal/hook                     controllers.PaypalController.hook
 POST           /:countryGroup/update-metadata   controllers.PaypalController.updateMetadata(countryGroup:CountryGroup)
 


### PR DESCRIPTION
We would like to add one-off contributions to **support the Guardian** platform. In order to do so, we are using the contributions endpoint. Therefore we are introducing some changes in contributions frontend:

* `paypal/auth` endpoint handles `OPTIONS` HTTP requests.
* Added a `supportRedirect` field in `auth` and `executePayment` endopoints.
* If the supportRedirect parameter equals to true, after being processed by paypal we redirect the user to `support-frontend`'s thank you page.

## Support Flow
![paypaloneoff](https://user-images.githubusercontent.com/825398/29084831-37b51420-7c65-11e7-81a4-faf073bb23cc.gif)

## Related PR
https://github.com/guardian/support-frontend/pull/163


