### PR TITLE
Integrate with paypal on mobile

### DIFF
--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -67,7 +67,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
       }
       .fold(error => {
         logger.error(s"Unable to capture the payment: $error")
-        InternalServerError(error.message)
+        InternalServerError(Json.toJson(error))
       }, {_ => Ok})
   }
 

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -47,9 +47,9 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
     val paypalService: PaypalService = paymentServices.paypalServiceFor(request)
 
     paypalService.capturePayment(captureBody.paymentId)
-      .map { payment =>
+      .map { capture =>
         paypalService.storeMetaData(
-          paymentId = payment.getId,
+          paymentId = capture.getParentPayment,
           testAllocations = request.testAllocations,
           cmp = captureBody.cmp,
           intCmp = captureBody.intCmp,
@@ -63,12 +63,12 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
         ).leftMap { errorMessage =>
           error(s"Unable to store the metadata while capturing the payment. Continuing anyway. Error: $errorMessage")
         }
-        payment
+        capture
       }
       .fold(error => {
         logger.error(s"Unable to capture the payment: $error")
         InternalServerError(Json.toJson(error))
-      }, {_ => Ok})
+      }, _ => Ok)
   }
 
   def executePayment(

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -62,7 +62,10 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
           ophanVisitId = None
         )
       }
-      .fold({_ => InternalServerError}, {_ => Ok})
+      .fold(error => {
+        logger.error(s"Unable to capture the payment: $error")
+        InternalServerError(error)
+      }, {_ => Ok})
   }
 
   def executePayment(

--- a/app/controllers/httpmodels/AuthRequest.scala
+++ b/app/controllers/httpmodels/AuthRequest.scala
@@ -4,6 +4,7 @@ import com.gu.i18n.CountryGroup
 import com.netaporter.uri.Uri
 import com.paypal.api.payments.Payment
 import play.api.libs.functional.syntax._
+import models.PaypalApiError
 import play.api.libs.json.Reads.min
 import play.api.libs.json._
 import utils.JsonUtils._
@@ -70,12 +71,12 @@ object AuthResponse {
 
   import scala.collection.JavaConverters._
 
-  def fromPayment(payment: Payment): Either[String, AuthResponse] = Either.fromOption(for {
+  def fromPayment(payment: Payment): Either[PaypalApiError, AuthResponse] = Either.fromOption(for {
     links <- Option(payment.getLinks)
     approvalLinks <- links.asScala.find(_.getRel.equalsIgnoreCase("approval_url"))
     approvalUrl <- Option(approvalLinks.getHref)
     paymentId <- Option(payment.getId)
-  } yield AuthResponse(Uri.parse(approvalUrl), paymentId), "Unable to parse payment")
+  } yield AuthResponse(Uri.parse(approvalUrl), paymentId), PaypalApiError("Unable to parse payment"))
 
   implicit val uriWrites = new Writes[Uri] {
     override def writes(uri: Uri): JsValue = JsString(uri.toString)

--- a/app/controllers/httpmodels/AuthRequest.scala
+++ b/app/controllers/httpmodels/AuthRequest.scala
@@ -76,7 +76,7 @@ object AuthResponse {
     approvalLinks <- links.asScala.find(_.getRel.equalsIgnoreCase("approval_url"))
     approvalUrl <- Option(approvalLinks.getHref)
     paymentId <- Option(payment.getId)
-  } yield AuthResponse(Uri.parse(approvalUrl), paymentId), PaypalApiError("Unable to parse payment"))
+  } yield AuthResponse(Uri.parse(approvalUrl), paymentId), PaypalApiError.fromString("Unable to parse payment"))
 
   implicit val uriWrites = new Writes[Uri] {
     override def writes(uri: Uri): JsValue = JsString(uri.toString)

--- a/app/controllers/httpmodels/CaptureRequest.scala
+++ b/app/controllers/httpmodels/CaptureRequest.scala
@@ -1,0 +1,19 @@
+package controllers.httpmodels
+
+import models.IdentityId
+import play.api.libs.json.{Format, Json}
+
+case class CaptureRequest (
+  paymentId: String,
+  platform: String,
+  idUser: Option[IdentityId],
+  cmp: Option[String],
+  intCmp: Option[String],
+  refererPageviewId: Option[String],
+  refererUrl: Option[String],
+  ophanPageviewId: Option[String],
+  ophanBrowserId: Option[String])
+
+object CaptureRequest {
+  implicit val jf: Format[CaptureRequest] = Json.format[CaptureRequest]
+}

--- a/app/controllers/httpmodels/CaptureRequest.scala
+++ b/app/controllers/httpmodels/CaptureRequest.scala
@@ -1,7 +1,7 @@
 package controllers.httpmodels
 
 import models.IdentityId
-import play.api.libs.json.{Format, Json}
+import play.api.libs.json.{Json, Reads}
 
 case class CaptureRequest (
   paymentId: String,
@@ -15,5 +15,5 @@ case class CaptureRequest (
   ophanBrowserId: Option[String])
 
 object CaptureRequest {
-  implicit val jf: Format[CaptureRequest] = Json.format[CaptureRequest]
+  implicit val captureRequestReads: Reads[CaptureRequest] = Json.reads[CaptureRequest]
 }

--- a/app/models/PaymentHook.scala
+++ b/app/models/PaymentHook.scala
@@ -30,8 +30,11 @@ object PaymentStatus extends Enum[PaymentStatus] {
   val paypalReads = new Reads[PaymentStatus] {
     override def reads(json: JsValue): JsResult[PaymentStatus] = json match {
       case JsString("PAYMENT.SALE.COMPLETED") => JsSuccess(Paid)
+      case JsString("PAYMENT.CAPTURE.COMPLETED") => JsSuccess(Paid)
       case JsString("PAYMENT.SALE.DENIED") => JsSuccess(Failed)
+      case JsString("PAYMENT.CAPTURE.DENIED") => JsSuccess(Failed)
       case JsString("PAYMENT.SALE.REFUNDED") => JsSuccess(Refunded)
+      case JsString("PAYMENT.CAPTURE.REFUNDED") => JsSuccess(Refunded)
       case JsString(wrongStatus) => JsError(s"Unexpected paypal status: $wrongStatus")
       case _ => JsError("Unknown paypal status type, a JsString was expected")
     }

--- a/app/models/PaymentHook.scala
+++ b/app/models/PaymentHook.scala
@@ -67,8 +67,8 @@ case class PaymentHook(
 )
 
 object PaymentHook {
-  def fromPaypal(paypalHook: PaypalHook): PaymentHook = PaymentHook(
-    contributionId = paypalHook.contributionId,
+  def fromPaypal(paypalHook: PaypalHook, contributionId: ContributionId): PaymentHook = PaymentHook(
+    contributionId = contributionId,
     paymentId = paypalHook.paymentId,
     provider = Paypal,
     created = paypalHook.created,
@@ -93,7 +93,7 @@ object PaymentHook {
 }
 
 case class PaypalHook(
-  contributionId: ContributionId,
+  contributionId: Option[ContributionId],
   paymentId: String,
   created: DateTime,
   currency: String,
@@ -106,7 +106,7 @@ object PaypalHook {
     override def reads(json: JsValue): JsResult[PaypalHook] = {
       for {
         resource <- (json \ "resource").validate[JsObject]
-        contributionId <- (resource \ "custom").validate[ContributionId]
+        contributionId <- (resource \ "custom").validateOpt[ContributionId]
         paymentId <- (resource \ "parent_payment").validate[String]
         created <- (resource \ "create_time").validate[String]
         currency <- (resource \ "amount" \ "currency").validate[String]

--- a/app/models/PaypalApiError.scala
+++ b/app/models/PaypalApiError.scala
@@ -3,7 +3,7 @@ package models
 import com.paypal.api.payments.{Error, ErrorDetails}
 import com.paypal.base.rest.PayPalRESTException
 import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
-import play.api.libs.json.{JsValue, Json, Writes}
+import play.api.libs.json.{Json, Writes}
 import scala.collection.JavaConverters._
 
 sealed trait PaypalErrorType extends EnumEntry
@@ -28,7 +28,7 @@ case class PaypalApiError(
 )
 
 object PaypalApiError {
-  def apply(message: String): PaypalApiError = PaypalApiError(PaypalErrorType.Other, message)
+  def fromString(message: String): PaypalApiError = PaypalApiError(PaypalErrorType.Other, message)
 
   private def detailToString(details: ErrorDetails): String =
     s"""
@@ -45,14 +45,8 @@ object PaypalApiError {
         .mkString(";\n")
       PaypalApiError(PaypalErrorType.fromPaypalError(paypalException.getDetails), details)
     case exception: Exception =>
-      PaypalApiError(exception.getMessage)
+      PaypalApiError.fromString(exception.getMessage)
   }
 
-  // defining the Writes manually, otherwise Play-Json gets offended by the overloaded "apply" just above
-  implicit val jf: Writes[PaypalApiError] = new Writes[PaypalApiError] {
-    override def writes(o: PaypalApiError): JsValue = Json.obj(
-      "errorType" -> o.errorType,
-      "message" -> o.message
-    )
-  }
+  implicit val jf: Writes[PaypalApiError] = Json.writes[PaypalApiError]
 }

--- a/app/models/PaypalApiError.scala
+++ b/app/models/PaypalApiError.scala
@@ -1,9 +1,10 @@
 package models
 
-import com.paypal.api.payments.Error
+import com.paypal.api.payments.{Error, ErrorDetails}
+import com.paypal.base.rest.PayPalRESTException
 import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
 import play.api.libs.json.{JsValue, Json, Writes}
-
+import scala.collection.JavaConverters._
 
 sealed trait PaypalErrorType extends EnumEntry
 
@@ -28,6 +29,24 @@ case class PaypalApiError(
 
 object PaypalApiError {
   def apply(message: String): PaypalApiError = PaypalApiError(PaypalErrorType.Other, message)
+
+  private def detailToString(details: ErrorDetails): String =
+    s"""
+       |field: ${details.getField}
+       |issue: ${details.getIssue}
+       |""".stripMargin
+
+  def fromThrowable(exception: Throwable): PaypalApiError = exception match {
+    case paypalException: PayPalRESTException =>
+      val details = Option(paypalException.getDetails)
+        .flatMap(d => Option(d.getDetails))
+        .map(_.asScala).getOrElse(Nil)
+        .map(detailToString)
+        .mkString(";\n")
+      PaypalApiError(PaypalErrorType.fromPaypalError(paypalException.getDetails), details)
+    case exception: Exception =>
+      PaypalApiError(exception.getMessage)
+  }
 
   // defining the Writes manually, otherwise Play-Json gets offended by the overloaded "apply" just above
   implicit val jf: Writes[PaypalApiError] = new Writes[PaypalApiError] {

--- a/app/models/PaypalApiError.scala
+++ b/app/models/PaypalApiError.scala
@@ -1,12 +1,13 @@
 package models
 
 import com.paypal.api.payments.Error
-import enumeratum.{Enum, EnumEntry}
+import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
+import play.api.libs.json.{JsValue, Json, Writes}
 
 
 sealed trait PaypalErrorType extends EnumEntry
 
-object PaypalErrorType extends Enum[PaypalErrorType] {
+object PaypalErrorType extends Enum[PaypalErrorType] with PlayJsonEnum[PaypalErrorType] {
   val values = findValues
 
   case object NotFound extends PaypalErrorType
@@ -25,4 +26,12 @@ case class PaypalApiError(
 
 object PaypalApiError {
   def apply(message: String): PaypalApiError = PaypalApiError(PaypalErrorType.Other, message)
+
+  // defining the Writes manually, otherwise Play-Json gets offended by the overloaded "apply" just above
+  implicit val jf: Writes[PaypalApiError] = new Writes[PaypalApiError] {
+    override def writes(o: PaypalApiError): JsValue = Json.obj(
+      "errorType" -> o.errorType,
+      "message" -> o.message
+    )
+  }
 }

--- a/app/models/PaypalApiError.scala
+++ b/app/models/PaypalApiError.scala
@@ -11,10 +11,12 @@ object PaypalErrorType extends Enum[PaypalErrorType] with PlayJsonEnum[PaypalErr
   val values = findValues
 
   case object NotFound extends PaypalErrorType
+  case object PaymentAlreadyDone extends PaypalErrorType
   case object Other extends PaypalErrorType
 
   def fromPaypalError(error: Error): PaypalErrorType = error.getName match {
     case "INVALID_RESOURCE_ID" => NotFound
+    case "PAYMENT_ALREADY_DONE" => PaymentAlreadyDone
     case _ => Other
   }
 }

--- a/app/models/PaypalApiError.scala
+++ b/app/models/PaypalApiError.scala
@@ -1,0 +1,28 @@
+package models
+
+import com.paypal.api.payments.Error
+import enumeratum.{Enum, EnumEntry}
+
+
+sealed trait PaypalErrorType extends EnumEntry
+
+object PaypalErrorType extends Enum[PaypalErrorType] {
+  val values = findValues
+
+  case object NotFound extends PaypalErrorType
+  case object Other extends PaypalErrorType
+
+  def fromPaypalError(error: Error): PaypalErrorType = error.getName match {
+    case "INVALID_RESOURCE_ID" => NotFound
+    case _ => Other
+  }
+}
+
+case class PaypalApiError(
+  errorType: PaypalErrorType,
+  message: String
+)
+
+object PaypalApiError {
+  def apply(message: String): PaypalApiError = PaypalApiError(PaypalErrorType.Other, message)
+}

--- a/app/models/PaypalApiError.scala
+++ b/app/models/PaypalApiError.scala
@@ -48,5 +48,5 @@ object PaypalApiError {
       PaypalApiError.fromString(exception.getMessage)
   }
 
-  implicit val jf: Writes[PaypalApiError] = Json.writes[PaypalApiError]
+  implicit val paypalApiErrorWrite: Writes[PaypalApiError] = Json.writes[PaypalApiError]
 }

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -133,7 +133,7 @@ class PaypalService(
     val paymentExecution = new PaymentExecution().setPayerId(payerId)
     asyncExecute(payment.execute(apiContext, paymentExecution)) flatMap { payment =>
       if (payment.getState.toUpperCase != "APPROVED") {
-        EitherT.left(Future.successful(PaypalApiError(s"payment returned with state: ${payment.getState}")))
+        EitherT.left(Future.successful(PaypalApiError.fromString(s"payment returned with state: ${payment.getState}")))
       } else EitherT.pure(payment)
     }
   }
@@ -142,7 +142,7 @@ class PaypalService(
     Future(block).attemptT.leftMap { t: Throwable =>
       val message = s"Unable to $action"
       error(message, t)
-      PaypalApiError(message)
+      PaypalApiError.fromString(message)
     }
   }
 
@@ -168,7 +168,7 @@ class PaypalService(
 
     result flatMap { capture =>
       if (capture.getState.toUpperCase != "COMPLETED") {
-        EitherT.left(Future.successful(PaypalApiError(s"payment returned with state: ${capture.getState}")))
+        EitherT.left(Future.successful(PaypalApiError.fromString(s"payment returned with state: ${capture.getState}")))
       } else EitherT.pure(capture)
     }
   }

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -170,7 +170,7 @@ class PaypalService(
       if (Option(transaction.getCustom).isDefined) {
         EitherT.pure(())
       } else {
-        val patch = new Patch("replace", "/transactions/0/custom")
+        val patch = new Patch("add", "/transactions/0/custom")
         patch.setValue(UUID.randomUUID())
         asyncExecute(payment.update(apiContext, List(patch).asJava))
       }

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -65,7 +65,9 @@ class PaypalService(
     def exceptionToPaypalError(exception: Throwable): PaypalApiError = exception match {
       case paypalException: PayPalRESTException =>
         error("Error while calling Paypal API", paypalException)
-        val details = paypalException.getDetails.getDetails.asScala
+        val details = Option(paypalException.getDetails)
+          .flatMap(d => Option(d.getDetails))
+          .map(_.asScala).getOrElse(Nil)
           .map(detailToString)
           .mkString(";\n")
         PaypalApiError(PaypalErrorType.fromPaypalError(paypalException.getDetails), details)

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -54,17 +54,30 @@ class PaypalService(
 
   def apiContext: APIContext = new APIContext(credentials.clientId, credentials.clientSecret, config.paypalMode)
 
-  private def asyncExecute[A](block: => A)(implicit tags: LoggingTags): EitherT[Future, PaypalApiError, A] = EitherT(Future {
-    val result = Try(block)
-    Either.fromTry(result).leftMap {
+  private def asyncExecute[A](block: => A)(implicit tags: LoggingTags): EitherT[Future, PaypalApiError, A] = {
+
+    def detailToString(details: ErrorDetails): String =
+      s"""
+       |field: ${details.getField}
+       |issue: ${details.getIssue}
+       |""".stripMargin
+
+    def exceptionToPaypalError(exception: Throwable): PaypalApiError = exception match {
       case paypalException: PayPalRESTException =>
         error("Error while calling Paypal API", paypalException)
-        PaypalApiError(PaypalErrorType.fromPaypalError(paypalException.getDetails), paypalException.getMessage)
+        val details = paypalException.getDetails.getDetails.asScala
+          .map(detailToString)
+          .mkString(";\n")
+        PaypalApiError(PaypalErrorType.fromPaypalError(paypalException.getDetails), details)
       case exception: Exception =>
         error("Error while calling PayPal API", exception)
         PaypalApiError(exception.getMessage)
     }
-  })
+
+    EitherT(Future {
+      Either.fromTry(Try(block)).leftMap(exceptionToPaypalError)
+    })
+  }
 
   private def fullName(payerInfo: PayerInfo): Option[String] = {
     val firstName = Option(payerInfo.getFirstName)

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,7 @@ val postgresql = "org.postgresql" % "postgresql" % "9.4.1209"
 val identityCookie =  "com.gu.identity" %% "identity-cookie" % "3.51"
 val scalaTest = "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0"
 val enumeratum = "com.beachape" %% "enumeratum" % "1.5.12"
+val enumeratumJson = "com.beachape" %% "enumeratum-play-json" % "1.5.12"
 val sqs = "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.36"
 val slugify = "com.github.slugify" % "slugify" % "2.1.7"
 val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.4" % Test
@@ -81,6 +82,7 @@ libraryDependencies ++= Seq(
     postgresql,
     identityCookie,
     enumeratum,
+    enumeratumJson,
     sqs,
     slugify,
     scalaCheck,

--- a/conf/routes
+++ b/conf/routes
@@ -17,6 +17,7 @@ GET            /healthcheck                     controllers.Healthcheck.healthch
 POST           /paypal/auth                     controllers.PaypalController.authorize
 OPTIONS        /paypal/auth                     controllers.PaypalController.authorizeOptions
 
+POST           /paypal/capture                  controllers.PaypalController.capturePayment
 GET            /paypal/:countryGroup/execute    controllers.PaypalController.executePayment(countryGroup: CountryGroup, paymentId, token, PayerID, CMP: Option[String], INTCMP: Option[String], refererPageviewId: Option[String], refererUrl: Option[String],pvid: Option[String], bid: Option[String], ophanVisitId: Option[String], supportRedirect: Option[Boolean])
 POST           /paypal/hook                     controllers.PaypalController.hook
 POST           /:countryGroup/update-metadata   controllers.PaypalController.updateMetadata(countryGroup:CountryGroup)

--- a/test/controllers/PaypalControllerSpec.scala
+++ b/test/controllers/PaypalControllerSpec.scala
@@ -139,7 +139,7 @@ class PaypalControllerSpec extends PlaySpec
     "generate correct redirect URL for support's successful PayPal payments" in {
       val fixture = new PaypalControllerFixture {
         Mockito.when(mockPaypalService.executePayment(Matchers.anyString, Matchers.anyString)(Matchers.any[LoggingTags]))
-          .thenReturn(EitherT.right[Future, String, Payment](Future.successful(mockPaypalPayment)))
+          .thenReturn(EitherT.right[Future, PaypalApiError, Payment](Future.successful(mockPaypalPayment)))
       }
 
       val result: Future[Result] = executeSupportPayment(fixture.controller)(fakeRequest)

--- a/test/controllers/PaypalControllerSpec.scala
+++ b/test/controllers/PaypalControllerSpec.scala
@@ -7,7 +7,7 @@ import com.gu.i18n.{CountryGroup, GBP}
 import com.paypal.api.payments.{Capture, Payment}
 import configuration.{CorsConfig, SupportConfig}
 import fixtures.TestApplicationFactory
-import models.{ContributionAmount, IdentityId, SavedContributionData}
+import models.{ContributionAmount, IdentityId, PaypalApiError, SavedContributionData}
 import monitoring.{CloudWatchMetrics, LoggingTags}
 import org.mockito.{ArgumentCaptor, Matchers, Mockito}
 import org.scalatest.mockito.MockitoSugar
@@ -151,7 +151,7 @@ class PaypalControllerSpec extends PlaySpec
     "generate correct redirect URL for successful PayPal payments" in {
       val fixture = new PaypalControllerFixture {
         Mockito.when(mockPaypalService.executePayment(Matchers.anyString, Matchers.anyString)(Matchers.any[LoggingTags]))
-          .thenReturn(EitherT.pure[Future, String, Payment](mockPaypalPayment))
+          .thenReturn(EitherT.pure[Future, PaypalApiError, Payment](mockPaypalPayment))
       }
 
       val result: Future[Result] = executePayment(fixture.controller)(fakeRequest)
@@ -165,7 +165,7 @@ class PaypalControllerSpec extends PlaySpec
     "generate correct redirect URL for unsuccessful PayPal payments" in {
       val fixture = new PaypalControllerFixture {
         Mockito.when(mockPaypalService.executePayment(Matchers.anyString, Matchers.anyString)(Matchers.any[LoggingTags]))
-          .thenReturn(EitherT.left[Future, String, Payment](Future.successful("Error")))
+          .thenReturn(EitherT.left[Future, PaypalApiError, Payment](Future.successful(PaypalApiError("Error"))))
       }
 
       val result: Future[Result] = executePayment(fixture.controller)(fakeRequest)
@@ -188,7 +188,7 @@ class PaypalControllerSpec extends PlaySpec
     "capture a payment made on mobile" in {
       val fixture = new PaypalControllerFixture {
         Mockito.when(mockPaypalService.capturePayment(Matchers.anyString)(Matchers.any[LoggingTags]))
-          .thenReturn(EitherT.pure[Future, String, Capture](mock[Capture]))
+          .thenReturn(EitherT.pure[Future, PaypalApiError, Capture](mock[Capture]))
       }
 
       val result: Future[Result] = Helpers.call(fixture.controller.capturePayment, captureRequest)
@@ -200,7 +200,7 @@ class PaypalControllerSpec extends PlaySpec
     "capture a payment even if storing the metadata failed" in {
       val fixture = new PaypalControllerFixture {
         Mockito.when(mockPaypalService.capturePayment(Matchers.anyString)(Matchers.any[LoggingTags]))
-          .thenReturn(EitherT.pure[Future, String, Capture](mock[Capture]))
+          .thenReturn(EitherT.pure[Future, PaypalApiError, Capture](mock[Capture]))
 
         Mockito.when(mockPaypalService.storeMetaData(
           paymentId = Matchers.any[String],

--- a/test/controllers/PaypalControllerSpec.scala
+++ b/test/controllers/PaypalControllerSpec.scala
@@ -165,7 +165,7 @@ class PaypalControllerSpec extends PlaySpec
     "generate correct redirect URL for unsuccessful PayPal payments" in {
       val fixture = new PaypalControllerFixture {
         Mockito.when(mockPaypalService.executePayment(Matchers.anyString, Matchers.anyString)(Matchers.any[LoggingTags]))
-          .thenReturn(EitherT.left[Future, PaypalApiError, Payment](Future.successful(PaypalApiError("Error"))))
+          .thenReturn(EitherT.left[Future, PaypalApiError, Payment](Future.successful(PaypalApiError.fromString("Error"))))
       }
 
       val result: Future[Result] = executePayment(fixture.controller)(fakeRequest)

--- a/test/controllers/PaypalControllerSpec.scala
+++ b/test/controllers/PaypalControllerSpec.scala
@@ -1,9 +1,10 @@
 package controllers
 
 import abtests.Allocation
+import akka.stream.Materializer
 import cats.data.EitherT
 import com.gu.i18n.{CountryGroup, GBP}
-import com.paypal.api.payments.Payment
+import com.paypal.api.payments.{Capture, Payment}
 import configuration.{CorsConfig, SupportConfig}
 import fixtures.TestApplicationFactory
 import models.{ContributionAmount, IdentityId, SavedContributionData}
@@ -14,10 +15,12 @@ import org.scalatestplus.play._
 import play.api.http.{HeaderNames, Status}
 import play.api.mvc._
 import play.api.test._
+import play.api.test.Helpers._
 import play.filters.csrf.CSRFCheck
 import services.{PaymentServices, PaypalService}
 import cats.instances.future._
 import org.mockito.internal.verification.VerificationModeFactory
+import play.api.libs.json.Json
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
@@ -97,6 +100,7 @@ class PaypalControllerSpec extends PlaySpec
   with BaseOneAppPerSuite {
 
   implicit val executionContext: ExecutionContext = app.actorSystem.dispatcher
+  implicit val mat: Materializer = app.materializer
 
   val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/").withHeaders(("Accept", "text/html"))
 
@@ -170,6 +174,56 @@ class PaypalControllerSpec extends PlaySpec
       redirectLocation(result).mustBe(Some("/uk?error_code=PaypalError"))
 
       fixture.numberOfCallsToStoreMetaDataMustBe(0)
+    }
+
+    val captureRequest = FakeRequest("POST", "/paypal/capture").withJsonBody(Json.parse(
+      """{
+            "paymentId": "PAY_u27dioc90iojdew",
+            "platform": "android",
+            "idUser": "abc123",
+            "intCmp": "SOME_CMP_CODE"
+           }
+        """.stripMargin))
+
+    "capture a payment made on mobile" in {
+      val fixture = new PaypalControllerFixture {
+        Mockito.when(mockPaypalService.capturePayment(Matchers.anyString)(Matchers.any[LoggingTags]))
+          .thenReturn(EitherT.pure[Future, String, Capture](mock[Capture]))
+      }
+
+      val result: Future[Result] = Helpers.call(fixture.controller.capturePayment, captureRequest)
+      status(result).mustBe(200)
+
+      fixture.numberOfCallsToStoreMetaDataMustBe(1)
+    }
+
+    "capture a payment even if storing the metadata failed" in {
+      val fixture = new PaypalControllerFixture {
+        Mockito.when(mockPaypalService.capturePayment(Matchers.anyString)(Matchers.any[LoggingTags]))
+          .thenReturn(EitherT.pure[Future, String, Capture](mock[Capture]))
+
+        Mockito.when(mockPaypalService.storeMetaData(
+          paymentId = Matchers.any[String],
+          testAllocations = Matchers.any[Set[Allocation]],
+          cmp = Matchers.any[Option[String]],
+          intCmp = Matchers.any[Option[String]],
+          refererPageviewId = Matchers.any[Option[String]],
+          refererUrl = Matchers.any[Option[String]],
+          ophanPageviewId = Matchers.any[Option[String]],
+          ophanBrowserId = Matchers.any[Option[String]],
+          idUser = Matchers.any[Option[IdentityId]],
+          platform = Matchers.any[Option[String]],
+          ophanVisitId = Matchers.any[Option[String]]
+        )(Matchers.any[LoggingTags]))
+          .thenReturn(EitherT.left[Future, String, SavedContributionData](Future.successful("Error")))
+      }
+
+
+
+      val result: Future[Result] = Helpers.call(fixture.controller.capturePayment, captureRequest)
+      status(result).mustBe(200)
+
+      fixture.numberOfCallsToStoreMetaDataMustBe(1)
     }
   }
 }

--- a/test/models/PaymentHookSpec.scala
+++ b/test/models/PaymentHookSpec.scala
@@ -9,7 +9,9 @@ import models.PaymentMode.Testing
 
 class PaymentHookSpec extends WordSpec with MustMatchers {
 
+
   "A Payment hook" must {
+    val contributionId = ContributionId("2e97dfb8-8b6c-4689-87de-84d2bb8b59bf")
     "be able to parse paypal's json" in {
 
       val json = Json.parse(paypalJson)
@@ -17,7 +19,7 @@ class PaymentHookSpec extends WordSpec with MustMatchers {
 
       jsResult mustBe a [JsSuccess[_]]
       jsResult.get mustEqual PaypalHook(
-        contributionId = ContributionId("2e97dfb8-8b6c-4689-87de-84d2bb8b59bf"),
+        contributionId = Some(contributionId),
         paymentId = "PAY-9D679537LH910742AK6VPPZI",
         created = new DateTime("2016-08-10T09:49:14Z"),
         currency = "GBP",
@@ -28,11 +30,11 @@ class PaymentHookSpec extends WordSpec with MustMatchers {
     "be able to parse paypal's json and convert it to a payment hook" in {
 
       val json = Json.parse(paypalJson)
-      val jsResult = PaypalHook.reader.reads(json).map(hook => PaymentHook.fromPaypal(hook))
+      val jsResult = PaypalHook.reader.reads(json).map(hook => PaymentHook.fromPaypal(hook, contributionId))
 
       jsResult mustBe a [JsSuccess[_]]
       jsResult.get mustEqual PaymentHook(
-        contributionId = ContributionId("2e97dfb8-8b6c-4689-87de-84d2bb8b59bf"),
+        contributionId = contributionId,
         paymentId = "PAY-9D679537LH910742AK6VPPZI",
         provider = Paypal,
         created = new DateTime("2016-08-10T09:49:14Z"),


### PR DESCRIPTION
When using the paypal SDK on android, the payment cannot be executed, but instead need to be "captured"

This PR provides an endpoint to capture a payment. It also provided a more sane type for handling paypal errors to enable us to send a reasonable error back to the client side if necessary.

Finally, it also adds support for the capture events at the webhook level.

Before merging this PR, I will therefore need to modify the webhook configuration in the paypal console to enable the capture events.

@guardian/contributions 
cc @mohammad-haque 