### PR TITLE
Firefox fix

### DIFF
--- a/assets/javascripts/src/components/inline-payment/ContributeButton.jsx
+++ b/assets/javascripts/src/components/inline-payment/ContributeButton.jsx
@@ -5,7 +5,7 @@ import { h } from 'preact';
 export default class ContributeButton {
     render() {
         return <div class="paypal-button-wrapper">
-            <button type="button" id="contribution-button"></button>
+            <div id="contribution-button"></div>
         </div>;
     }
 

--- a/assets/stylesheets/inlinePayment.scss
+++ b/assets/stylesheets/inlinePayment.scss
@@ -150,7 +150,6 @@ body {
     @include fs-textSans(4);
     background: none;
     font-weight: bold;
-    flex: 1;
     margin-bottom: 0;
     text-align: center;
 }


### PR DESCRIPTION
Two Firefox fixes:

* make the PayPal button work
* correct width of "other amount field" (see screenshots below)

before
![screen shot 2017-08-11 at 11 30 13](https://user-images.githubusercontent.com/1064734/29209879-bca08e6a-7e88-11e7-8132-48f958e6c4d4.png)

after
![screen shot 2017-08-11 at 11 30 01](https://user-images.githubusercontent.com/1064734/29209881-bee09512-7e88-11e7-93fe-2b56ee47f133.png)



