### PR TITLE
reposition stripe payment complete reporting and add metric to track unhandled stripe failures

### DIFF
--- a/app/monitoring/CloudWatchMetrics.scala
+++ b/app/monitoring/CloudWatchMetrics.scala
@@ -68,7 +68,7 @@ class CloudWatchMetrics(cloudWatchClient: AmazonCloudWatchAsync) extends TagAwar
   }
 
   def logUnhandledPaymentFailure(paymentProvider: PaymentProvider, platform: String): Unit = {
-    put("payment-failure", paymentProvider, platform)
+    put("unhandled-payment-failure", paymentProvider, platform)
   }
 
   def logHookAttempt(paymentProvider: PaymentProvider, platform: String): Unit = {

--- a/app/monitoring/CloudWatchMetrics.scala
+++ b/app/monitoring/CloudWatchMetrics.scala
@@ -67,6 +67,10 @@ class CloudWatchMetrics(cloudWatchClient: AmazonCloudWatchAsync) extends TagAwar
     put("payment-failure", paymentProvider, platform)
   }
 
+  def logUnhandledPaymentFailure(paymentProvider: PaymentProvider, platform: String): Unit = {
+    put("payment-failure", paymentProvider, platform)
+  }
+
   def logHookAttempt(paymentProvider: PaymentProvider, platform: String): Unit = {
     put("payment-hook-attempt", paymentProvider, platform)
   }


### PR DESCRIPTION
This pull request repositions payment complete reporting in Stripe.controller so that it fires at the very last moment before user is redirected to thank-you page.

This is because there have been a number of false alarms as a result of payment being successful, but user not being shown the thank-you page. This calls the use of thank-you page as a reliable indicator of a successful payment into question and I have changed the librato metrics to instead alert on the Stripe Payment Success metric insted.
To minimise the chance of this alert not being triggered in the event of an unsuccessful payment, I have moved it into the redirect logic called at the very end of the "pay" function.

This pull request also adds a new metric to capture any Stripe payment failures that are not a direct result of Stripe responding that it does not accept thee payments. The idea of this metric is to capture edge cases such as timeouts.







Have you gone through the contributions flow for all test variants ?
