### PR TITLE
Provide Payment object instead of payment ID when storing PayPal metadata

### DIFF
--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -71,6 +71,9 @@ class PaypalService(
     }
   }
 
+  def getPayment(paymentId: String)(implicit tags: LoggingTags): EitherT[Future, PaypalApiError, Payment] =
+    asyncExecute(Payment.get(apiContext, paymentId))
+
   def getPayment(
     amount: BigDecimal,
     countryGroup: CountryGroup,
@@ -174,7 +177,7 @@ class PaypalService(
   }
 
   def storeMetaData(
-    paymentId: String,
+    payment: Payment,
     testAllocations: Set[Allocation],
     cmp: Option[String],
     intCmp: Option[String],
@@ -188,7 +191,6 @@ class PaypalService(
   )(implicit tags: LoggingTags): EitherT[Future, String, SavedContributionData] = {
 
     val contributionDataToSave = for {
-      payment <- asyncExecute(Payment.get(apiContext, paymentId))
       transaction <- attempt("get transaction")(payment.getTransactions.asScala.head)
       contributionId <- attempt("get custom field")(UUID.fromString(transaction.getCustom))
       created <- attempt("get payment date")(new DateTime(payment.getCreateTime))

--- a/test/controllers/PaypalControllerSpec.scala
+++ b/test/controllers/PaypalControllerSpec.scala
@@ -54,8 +54,11 @@ class PaypalControllerFixture(implicit ec: ExecutionContext) extends MockitoSuga
   Mockito.when(mockPaypalPayment.getPayer.getPayerInfo.getEmail)
     .thenReturn("a@b.com")
 
+  Mockito.when(mockPaypalService.getPayment(Matchers.anyString)(Matchers.any[LoggingTags]))
+    .thenReturn(EitherT.pure[Future, PaypalApiError, Payment](mockPaypalPayment))
+
   Mockito.when(mockPaypalService.storeMetaData(
-    paymentId = Matchers.any[String],
+    payment = Matchers.any[Payment],
     testAllocations = Matchers.any[Set[Allocation]],
     cmp = Matchers.any[Option[String]],
     intCmp = Matchers.any[Option[String]],
@@ -76,7 +79,7 @@ class PaypalControllerFixture(implicit ec: ExecutionContext) extends MockitoSuga
       ArgumentCaptor.forClass[A](classTag.runtimeClass.asInstanceOf[Class[A]]).capture()
 
     Mockito.verify(mockPaypalService, VerificationModeFactory.times(times)).storeMetaData(
-      captor[String],
+      captor[Payment],
       captor[Set[Allocation]],
       captor[Option[String]],
       captor[Option[String]],
@@ -203,7 +206,7 @@ class PaypalControllerSpec extends PlaySpec
           .thenReturn(EitherT.pure[Future, PaypalApiError, Capture](mock[Capture]))
 
         Mockito.when(mockPaypalService.storeMetaData(
-          paymentId = Matchers.any[String],
+          payment = Matchers.any[Payment],
           testAllocations = Matchers.any[Set[Allocation]],
           cmp = Matchers.any[Option[String]],
           intCmp = Matchers.any[Option[String]],


### PR DESCRIPTION
This is to prevent what seems to be an unneccessary call to the PayPal API, and will allow me to avoid any 3rd-party dependencies when sending Acquisition events (which will be in a future PR).

At the moment, we provide the payment ID to the `executePayment` call in the controller, which gives us back a `Payment`. We then pass the payment ID to the `storeMetaData` function which goes on to call the PayPal API to retrieve the Payment object. This seems redundant since we can instead provide the Payment from `executePayment` to `storeMetaData`, which is what this PR changes.