### PR TITLE
logging improvements to use play session id to track payments

### DIFF
--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -62,27 +62,20 @@ object CommonActions {
       case _ => _platform
     }
 
-    def playId: Option[String] = {
+    def playSessionId: Option[String] = {
       for {
         playSessionCookie <- request.cookies.get("PLAY_SESSION")
         value <- Option(playSessionCookie.value)
       } yield {
-        value.take(value.indexOf("-"))
+        value.takeWhile( _ != '-')
       }
     }
 
-    def initialSessionId: String = {playId.getOrElse("")}
+    def initialSessionId: String = playSessionId.getOrElse("unknown_contributions_session")
 
     def sessionId: String = {
-      val payment_session = request.session.get("payment_session")
-      payment_session match {
-        case Some(id) =>
-          if(id.nonEmpty)
-            id
-          else
-            initialSessionId
-        case None => initialSessionId
-          }
+      val contributionSession = request.session.get("contributions_session")
+      contributionSession.getOrElse(initialSessionId)
     }
 
     def isAndroid: Boolean = platform == "android"

--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -74,8 +74,7 @@ object CommonActions {
     def initialSessionId: String = playSessionId.getOrElse("unknown_contributions_session")
 
     def sessionId: String = {
-      val contributionSession = request.session.get("contributions_session")
-      contributionSession.getOrElse(initialSessionId)
+      request.session.get("contributions_session").getOrElse(initialSessionId)
     }
 
     def isAndroid: Boolean = platform == "android"

--- a/app/actions/CommonActions.scala
+++ b/app/actions/CommonActions.scala
@@ -62,6 +62,29 @@ object CommonActions {
       case _ => _platform
     }
 
+    def playId: Option[String] = {
+      for {
+        playSessionCookie <- request.cookies.get("PLAY_SESSION")
+        value <- Option(playSessionCookie.value)
+      } yield {
+        value.take(value.indexOf("-"))
+      }
+    }
+
+    def initialSessionId: String = {playId.getOrElse("")}
+
+    def sessionId: String = {
+      val payment_session = request.session.get("payment_session")
+      payment_session match {
+        case Some(id) =>
+          if(id.nonEmpty)
+            id
+          else
+            initialSessionId
+        case None => initialSessionId
+          }
+    }
+
     def isAndroid: Boolean = platform == "android"
     def isIos: Boolean = platform == "ios"
     def isMobile: Boolean = isAndroid || isIos

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -99,7 +99,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
         CSRF.getToken.map(_.value),
         request.isAllocated(Test.landingPageTest, "with-copy"),
         disableStripe
-      )).addingToSession("contributions session" -> request.sessionId)
+      )).addingToSession("contributions_session" -> request.sessionId)
     }
   }
 

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -52,7 +52,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       description = Some("By making a contribution, you’ll be supporting independent journalism that speaks truth to power"),
       customSignInUrl = Some((Config.idWebAppUrl / "signin") ? ("skipConfirmation" -> "true"))
     )
-    info(s"Paypal post-payment page displayed for contributions_session id: ${request.sessionId}, platform: ${request.platform}.")
+    info(s"Paypal post-payment page displayed for contributions session id: ${request.sessionId}, platform: ${request.platform}.")
     cloudWatchMetrics.logPostPaymentPageDisplayed(request.paymentProvider, request.platform)
     Ok(views.html.giraffe.postPayment(pageInfo, countryGroup))
   }
@@ -82,7 +82,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       val maxAmountInLocalCurrency = MaxAmount.forCurrency(countryGroup.currency)
       val creditCardExpiryYears = CreditCardExpiryYears(LocalDate.now.getYear, 10)
 
-      info(s"Home page displayed for contributions_session id: ${request.sessionId}, platform: ${request.platform}.")
+      info(s"Home page displayed for contributions session id: ${request.sessionId}, platform: ${request.platform}.")
       cloudWatchMetrics.logHomePage(request.platform)
 
       Ok(views.html.giraffe.contribute(
@@ -99,7 +99,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
         CSRF.getToken.map(_.value),
         request.isAllocated(Test.landingPageTest, "with-copy"),
         disableStripe
-      )).addingToSession("contributions_session" -> request.sessionId)
+      )).addingToSession("contributions session" -> request.sessionId)
     }
   }
 
@@ -112,7 +112,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       .map(mobileRedirectUrl)
       .filter(_ => request.isIos)
 
-    info(s"Thank you page displayed. Contributions_session id: ${request.sessionId}, platform: ${request.platform}. Payment method used was: ${request.paymentProvider.getOrElse("unknown")}.")
+    info(s"Thank you page displayed. contributions session id: ${request.sessionId}, platform: ${request.platform}. Payment method used was: ${request.paymentProvider.getOrElse("unknown")}.")
     cloudWatchMetrics.logThankYouPageDisplayed(request.paymentProvider, request.platform)
 
     Ok(views.html.giraffe.thankyou(PageInfo(

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -52,7 +52,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       description = Some("By making a contribution, you’ll be supporting independent journalism that speaks truth to power"),
       customSignInUrl = Some((Config.idWebAppUrl / "signin") ? ("skipConfirmation" -> "true"))
     )
-    info(s"Paypal post-payment page displayed for payment_session id: ${request.sessionId}, platform: ${request.platform}.")
+    info(s"Paypal post-payment page displayed for contributions_session id: ${request.sessionId}, platform: ${request.platform}.")
     cloudWatchMetrics.logPostPaymentPageDisplayed(request.paymentProvider, request.platform)
     Ok(views.html.giraffe.postPayment(pageInfo, countryGroup))
   }
@@ -82,7 +82,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       val maxAmountInLocalCurrency = MaxAmount.forCurrency(countryGroup.currency)
       val creditCardExpiryYears = CreditCardExpiryYears(LocalDate.now.getYear, 10)
 
-      info(s"Home page displayed for payment_session id: ${request.sessionId}, platform: ${request.platform}.")
+      info(s"Home page displayed for contributions_session id: ${request.sessionId}, platform: ${request.platform}.")
       cloudWatchMetrics.logHomePage(request.platform)
 
       Ok(views.html.giraffe.contribute(
@@ -99,7 +99,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
         CSRF.getToken.map(_.value),
         request.isAllocated(Test.landingPageTest, "with-copy"),
         disableStripe
-      )).addingToSession("payment_session" -> request.sessionId)
+      )).addingToSession("contributions_session" -> request.sessionId)
     }
   }
 
@@ -112,7 +112,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       .map(mobileRedirectUrl)
       .filter(_ => request.isIos)
 
-    info(s"Thank you page displayed. Payment_session id: ${request.sessionId}, platform: ${request.platform}. Payment method used was: ${request.paymentProvider.getOrElse("unknown")}.")
+    info(s"Thank you page displayed. Contributions_session id: ${request.sessionId}, platform: ${request.platform}. Payment method used was: ${request.paymentProvider.getOrElse("unknown")}.")
     cloudWatchMetrics.logThankYouPageDisplayed(request.paymentProvider, request.platform)
 
     Ok(views.html.giraffe.thankyou(PageInfo(

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -52,7 +52,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       description = Some("By making a contribution, you’ll be supporting independent journalism that speaks truth to power"),
       customSignInUrl = Some((Config.idWebAppUrl / "signin") ? ("skipConfirmation" -> "true"))
     )
-    info(s"Paypal post-payment page displayed for play_session: ${request.sessionId}, platform: ${request.platform}.")
+    info(s"Paypal post-payment page displayed for payment_session id: ${request.sessionId}, platform: ${request.platform}.")
     cloudWatchMetrics.logPostPaymentPageDisplayed(request.paymentProvider, request.platform)
     Ok(views.html.giraffe.postPayment(pageInfo, countryGroup))
   }
@@ -82,7 +82,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       val maxAmountInLocalCurrency = MaxAmount.forCurrency(countryGroup.currency)
       val creditCardExpiryYears = CreditCardExpiryYears(LocalDate.now.getYear, 10)
 
-      info(s"Home page displayed for play_session: ${request.sessionId}, platform: ${request.platform}.")
+      info(s"Home page displayed for payment_session id: ${request.sessionId}, platform: ${request.platform}.")
       cloudWatchMetrics.logHomePage(request.platform)
 
       Ok(views.html.giraffe.contribute(
@@ -112,7 +112,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       .map(mobileRedirectUrl)
       .filter(_ => request.isIos)
 
-    info(s"Thank you page displayed. Play_session: ${request.sessionId}, platform: ${request.platform}. Payment method used was: ${request.paymentProvider.getOrElse("unknown")}.")
+    info(s"Thank you page displayed. Payment_session id: ${request.sessionId}, platform: ${request.platform}. Payment method used was: ${request.paymentProvider.getOrElse("unknown")}.")
     cloudWatchMetrics.logThankYouPageDisplayed(request.paymentProvider, request.platform)
 
     Ok(views.html.giraffe.thankyou(PageInfo(

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -52,7 +52,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       description = Some("By making a contribution, you’ll be supporting independent journalism that speaks truth to power"),
       customSignInUrl = Some((Config.idWebAppUrl / "signin") ? ("skipConfirmation" -> "true"))
     )
-    info(s"Paypal post-payment page displayed for request: ${request.id}, platform: ${request.platform}.")
+    info(s"Paypal post-payment page displayed for play_session: ${request.sessionId}, platform: ${request.platform}.")
     cloudWatchMetrics.logPostPaymentPageDisplayed(request.paymentProvider, request.platform)
     Ok(views.html.giraffe.postPayment(pageInfo, countryGroup))
   }
@@ -82,7 +82,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       val maxAmountInLocalCurrency = MaxAmount.forCurrency(countryGroup.currency)
       val creditCardExpiryYears = CreditCardExpiryYears(LocalDate.now.getYear, 10)
 
-      info(s"Home page displayed for request id: ${request.id}, platform: ${request.platform}.")
+      info(s"Home page displayed for play_session: ${request.sessionId}, platform: ${request.platform}.")
       cloudWatchMetrics.logHomePage(request.platform)
 
       Ok(views.html.giraffe.contribute(
@@ -99,7 +99,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
         CSRF.getToken.map(_.value),
         request.isAllocated(Test.landingPageTest, "with-copy"),
         disableStripe
-      ))
+      )).addingToSession("payment_session" -> request.sessionId)
     }
   }
 
@@ -112,7 +112,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       .map(mobileRedirectUrl)
       .filter(_ => request.isIos)
 
-    info(s"Thank you page displayed. Request id: ${request.id}, platform: ${request.platform}. Payment method used was: ${request.paymentProvider.getOrElse("unknown")}.")
+    info(s"Thank you page displayed. Play_session: ${request.sessionId}, platform: ${request.platform}. Payment method used was: ${request.paymentProvider.getOrElse("unknown")}.")
     cloudWatchMetrics.logThankYouPageDisplayed(request.paymentProvider, request.platform)
 
     Ok(views.html.giraffe.thankyou(PageInfo(

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -132,7 +132,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
           }
           redirectWithCampaignCodes(redirectUrl).addingToSession(session: _ *)
       }
-      info(s"Paypal payment from platform: ${request.platform} is successful. Payment_session id: ${request.sessionId}.")
+      info(s"Paypal payment from platform: ${request.platform} is successful. Contributions session id: ${request.sessionId}.")
       cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Paypal, request.platform)
       response.setCookie[ContribTimestampCookieAttributes](payment.getCreateTime)
     }
@@ -146,7 +146,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
 
   def authorize = checkToken {
     NoCacheAction.async(parse.json[AuthRequest]) { implicit request =>
-      info(s"Attempting to obtain paypal auth response. Payment_session id: ${request.sessionId}. Platform: ${request.platform}.")
+      info(s"Attempting to obtain paypal auth response. Contributions session id: ${request.sessionId}. Platform: ${request.platform}.")
       cloudWatchMetrics.logPaymentAuthAttempt(PaymentProvider.Paypal, request.platform)
       val authRequest = request.body
       val amount = capAmount(authRequest.amount, authRequest.countryGroup.currency)

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -63,12 +63,12 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
         platform = Some(captureBody.platform),
         ophanVisitId = None
       ).leftMap { errorMessage =>
-        error(s"Unable to store the metadata while capturing the payment. Continuing anyway. play_session: ${request.sessionId} Error: $errorMessage")
+        error(s"Unable to store the metadata while capturing the payment. Continuing anyway. payment_session id: ${request.sessionId} Error: $errorMessage")
       }
 
       capture
     }).fold(error => {
-      logger.error(s"Unable to capture the payment for play_session: ${request.sessionId}. Error message is: $error")
+      logger.error(s"Unable to capture the payment for payment_session id: ${request.sessionId}. Error message is: $error")
       InternalServerError(Json.toJson(error))
     }, _ => Ok)
   }
@@ -90,7 +90,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
 
     val paypalService = paymentServices.paypalServiceFor(request)
 
-    info(s"Attempting paypal payment for play_session: ${request.sessionId}")
+    info(s"Attempting paypal payment for payment_session id: ${request.sessionId}")
     cloudWatchMetrics.logPaymentAttempt(PaymentProvider.Paypal, request.platform)
 
     def storeMetaData(payment: Payment) =
@@ -109,7 +109,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
       )
 
     def notOkResult(paypalError: PaypalApiError): Result = {
-      error(s"Error executing PayPal payment for play_session: ${request.sessionId} \n\t error message: ${paypalError.message}")
+      error(s"Error executing PayPal payment for payment_session id: ${request.sessionId} \n\t error message: ${paypalError.message}")
       cloudWatchMetrics.logPaymentFailure(PaymentProvider.Paypal, request.platform)
       render {
         case Accepts.Json() => BadRequest(JsNull)
@@ -124,7 +124,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
         case Accepts.Html() =>
           val amount: Option[ContributionAmount] = paypalService.paymentAmount(payment)
           val email = payment.getPayer.getPayerInfo.getEmail
-          val session = List("email" -> email, "payment_session" -> request.sessionId,PaymentProvider.sessionKey -> PaymentProvider.Paypal.entryName) ++ amount.map("amount" -> _.show)
+          val session = List("email" -> email,PaymentProvider.sessionKey -> PaymentProvider.Paypal.entryName) ++ amount.map("amount" -> _.show)
           val redirectUrl = if (supportRedirect.getOrElse(false)) {
             supportConfig.thankYouURL
           } else {
@@ -132,7 +132,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
           }
           redirectWithCampaignCodes(redirectUrl).addingToSession(session: _ *)
       }
-      info(s"Paypal payment from platform: ${request.platform} is successful. Play_session: ${request.sessionId}.")
+      info(s"Paypal payment from platform: ${request.platform} is successful. Payment_session id: ${request.sessionId}.")
       cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Paypal, request.platform)
       response.setCookie[ContribTimestampCookieAttributes](payment.getCreateTime)
     }
@@ -146,7 +146,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
 
   def authorize = checkToken {
     NoCacheAction.async(parse.json[AuthRequest]) { implicit request =>
-      info(s"Attempting to obtain paypal auth response. Play_session: ${request.sessionId}. Platform: ${request.platform}.")
+      info(s"Attempting to obtain paypal auth response. Payment_session id: ${request.sessionId}. Platform: ${request.platform}.")
       cloudWatchMetrics.logPaymentAuthAttempt(PaymentProvider.Paypal, request.platform)
       val authRequest = request.body
       val amount = capAmount(authRequest.amount, authRequest.countryGroup.currency)
@@ -168,12 +168,12 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
 
       payment.subflatMap(AuthResponse.fromPayment).fold(
         err => {
-          error(s"Error getting PayPal auth response for play_session: ${request.sessionId}, platform: ${request.platform}.\n\t error message: $err")
+          error(s"Error getting PayPal auth response for payment_session id: ${request.sessionId}, platform: ${request.platform}.\n\t error message: $err")
           cloudWatchMetrics.logPaymentAuthFailure(PaymentProvider.Paypal, request.platform)
           InternalServerError("Error getting PayPal auth url").withHeaders(corsHeaders(request): _*)
         },
         authResponse => {
-          info(s"Paypal payment auth response successfully obtained for play_session: ${request.sessionId}, platform: ${request.platform}.")
+          info(s"Paypal payment auth response successfully obtained for payment_session id: ${request.sessionId}, platform: ${request.platform}.")
           cloudWatchMetrics.logPaymentAuthSuccess(PaymentProvider.Paypal, request.platform)
           Ok(Json.toJson(authResponse)).withHeaders(corsHeaders(request): _*)
         }

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -63,12 +63,12 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
         platform = Some(captureBody.platform),
         ophanVisitId = None
       ).leftMap { errorMessage =>
-        error(s"Unable to store the metadata while capturing the payment. Continuing anyway. Error: $errorMessage")
+        error(s"Unable to store the metadata while capturing the payment. Continuing anyway. play_session: ${request.sessionId} Error: $errorMessage")
       }
 
       capture
     }).fold(error => {
-      logger.error(s"Unable to capture the payment: $error")
+      logger.error(s"Unable to capture the payment for play_session: ${request.sessionId}. Error message is: $error")
       InternalServerError(Json.toJson(error))
     }, _ => Ok)
   }
@@ -90,7 +90,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
 
     val paypalService = paymentServices.paypalServiceFor(request)
 
-    info(s"Attempting paypal payment for id: ${request.id}")
+    info(s"Attempting paypal payment for play_session: ${request.sessionId}")
     cloudWatchMetrics.logPaymentAttempt(PaymentProvider.Paypal, request.platform)
 
     def storeMetaData(payment: Payment) =
@@ -109,7 +109,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
       )
 
     def notOkResult(paypalError: PaypalApiError): Result = {
-      error(s"Error executing PayPal payment for request id: ${request.id} \n\t error message: ${paypalError.message}")
+      error(s"Error executing PayPal payment for play_session: ${request.sessionId} \n\t error message: ${paypalError.message}")
       cloudWatchMetrics.logPaymentFailure(PaymentProvider.Paypal, request.platform)
       render {
         case Accepts.Json() => BadRequest(JsNull)
@@ -124,7 +124,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
         case Accepts.Html() =>
           val amount: Option[ContributionAmount] = paypalService.paymentAmount(payment)
           val email = payment.getPayer.getPayerInfo.getEmail
-          val session = List("email" -> email, PaymentProvider.sessionKey -> PaymentProvider.Paypal.entryName) ++ amount.map("amount" -> _.show)
+          val session = List("email" -> email, "payment_session" -> request.sessionId,PaymentProvider.sessionKey -> PaymentProvider.Paypal.entryName) ++ amount.map("amount" -> _.show)
           val redirectUrl = if (supportRedirect.getOrElse(false)) {
             supportConfig.thankYouURL
           } else {
@@ -132,7 +132,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
           }
           redirectWithCampaignCodes(redirectUrl).addingToSession(session: _ *)
       }
-      info(s"Paypal payment from platform: ${request.platform} is successful. Request id: ${request.id}.")
+      info(s"Paypal payment from platform: ${request.platform} is successful. Play_session: ${request.sessionId}.")
       cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Paypal, request.platform)
       response.setCookie[ContribTimestampCookieAttributes](payment.getCreateTime)
     }
@@ -146,7 +146,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
 
   def authorize = checkToken {
     NoCacheAction.async(parse.json[AuthRequest]) { implicit request =>
-      info(s"Attempting to obtain paypal auth response. Request id: ${request.id}. Platform: ${request.platform}.")
+      info(s"Attempting to obtain paypal auth response. Play_session: ${request.sessionId}. Platform: ${request.platform}.")
       cloudWatchMetrics.logPaymentAuthAttempt(PaymentProvider.Paypal, request.platform)
       val authRequest = request.body
       val amount = capAmount(authRequest.amount, authRequest.countryGroup.currency)
@@ -168,12 +168,12 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
 
       payment.subflatMap(AuthResponse.fromPayment).fold(
         err => {
-          error(s"Error getting PayPal auth response for request id: ${request.id}, platform: ${request.platform}.\n\t error message: $err")
+          error(s"Error getting PayPal auth response for play_session: ${request.sessionId}, platform: ${request.platform}.\n\t error message: $err")
           cloudWatchMetrics.logPaymentAuthFailure(PaymentProvider.Paypal, request.platform)
           InternalServerError("Error getting PayPal auth url").withHeaders(corsHeaders(request): _*)
         },
         authResponse => {
-          info(s"Paypal payment auth response successfully obtained for request id: ${request.id}, platform: ${request.platform}.")
+          info(s"Paypal payment auth response successfully obtained for play_session: ${request.sessionId}, platform: ${request.platform}.")
           cloudWatchMetrics.logPaymentAuthSuccess(PaymentProvider.Paypal, request.platform)
           Ok(Json.toJson(authResponse)).withHeaders(corsHeaders(request): _*)
         }

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -63,12 +63,12 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
         platform = Some(captureBody.platform),
         ophanVisitId = None
       ).leftMap { errorMessage =>
-        error(s"Unable to store the metadata while capturing the payment. Continuing anyway. Contributions_session id: ${request.sessionId} Error: $errorMessage")
+        error(s"Unable to store the metadata while capturing the payment. Continuing anyway. contributions session id: ${request.sessionId} Error: $errorMessage")
       }
 
       capture
     }).fold(error => {
-      logger.error(s"Unable to capture the payment for contributions_session id: ${request.sessionId}. Error message is: $error")
+      logger.error(s"Unable to capture the payment for contributions session id: ${request.sessionId}. Error message is: $error")
       InternalServerError(Json.toJson(error))
     }, _ => Ok)
   }
@@ -90,7 +90,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
 
     val paypalService = paymentServices.paypalServiceFor(request)
 
-    info(s"Attempting paypal payment for contributions_session id: ${request.sessionId}")
+    info(s"Attempting paypal payment for contributions session id: ${request.sessionId}")
     cloudWatchMetrics.logPaymentAttempt(PaymentProvider.Paypal, request.platform)
 
     def storeMetaData(payment: Payment) =
@@ -109,7 +109,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
       )
 
     def notOkResult(paypalError: PaypalApiError): Result = {
-      error(s"Error executing PayPal payment for contributions_session id: ${request.sessionId} \n\t error message: ${paypalError.message}")
+      error(s"Error executing PayPal payment for contributions session id: ${request.sessionId} \n\t error message: ${paypalError.message}")
       cloudWatchMetrics.logPaymentFailure(PaymentProvider.Paypal, request.platform)
       render {
         case Accepts.Json() => BadRequest(JsNull)
@@ -168,12 +168,12 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
 
       payment.subflatMap(AuthResponse.fromPayment).fold(
         err => {
-          error(s"Error getting PayPal auth response for contributions_session id: ${request.sessionId}, platform: ${request.platform}.\n\t error message: $err")
+          error(s"Error getting PayPal auth response for contributions session id: ${request.sessionId}, platform: ${request.platform}.\n\t error message: $err")
           cloudWatchMetrics.logPaymentAuthFailure(PaymentProvider.Paypal, request.platform)
           InternalServerError("Error getting PayPal auth url").withHeaders(corsHeaders(request): _*)
         },
         authResponse => {
-          info(s"Paypal payment auth response successfully obtained for contributions_session id: ${request.sessionId}, platform: ${request.platform}.")
+          info(s"Paypal payment auth response successfully obtained for contributions session id: ${request.sessionId}, platform: ${request.platform}.")
           cloudWatchMetrics.logPaymentAuthSuccess(PaymentProvider.Paypal, request.platform)
           Ok(Json.toJson(authResponse)).withHeaders(corsHeaders(request): _*)
         }

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -3,6 +3,7 @@ package controllers
 import java.lang.Math._
 import java.time.Instant
 
+import actions.CommonActions
 import actions.CommonActions._
 import cats.data.EitherT
 import cats.syntax.show._
@@ -38,7 +39,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
   // THIS ENDPOINT IS USED BY BOTH THE FRONTEND AND THE MOBILE-APP
   def pay = (NoCacheAction andThen MobileSupportAction andThen ABTestAction)
     .async(BodyParsers.jsonOrMultipart(ContributionRequest.contributionForm)) { implicit request =>
-    info(s"A Stripe payment is being attempted with request id: ${request.id}, from platform: ${request.platform}.")
+    info(s"A Stripe payment is being attempted with play_session: ${request.sessionId}, from platform: ${request.platform}.")
     cloudWatchMetrics.logPaymentAttempt(PaymentProvider.Stripe, request.platform)
 
     val form = request.body
@@ -79,7 +80,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
     val contributionAmount = ContributionAmount(BigDecimal(amount, 2), form.currency)
 
     def thankYouUri = if (request.isAndroid) {
-      info(s"Payment successful for request ${request.id} - redirected to external platform for thank you page. platform is: ${request.platform}.")
+      info(s"Payment successful for play_session: ${request.sessionId} - redirected to external platform for thank you page. platform is: ${request.platform}.")
       cloudWatchMetrics.logPaymentSuccessRedirected(PaymentProvider.Stripe, request.platform)
       mobileRedirectUrl(contributionAmount)
     } else {
@@ -130,7 +131,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
     }
 
     createCharge.map { charge =>
-      info(s"Stripe payment successful for request id: ${request.id}, from platform ${request.platform}")
+      info(s"Stripe payment successful for play_session: ${request.sessionId}, from platform ${request.platform}")
       cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Stripe, request.platform)
       val metadata = createMetaData(charge)
       storeMetaData(metadata) // fire and forget. If it fails we don't want to stop the user
@@ -143,7 +144,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
         .withHeaders(corsHeaders(request): _*)
     }.recover {
       case e: Stripe.Error => {
-        warn(s"Payment failed for request id: ${request.id}, from platform: ${request.platform}, \n\t with code: ${e.decline_code} \n\t and message: ${e.message}.")
+        warn(s"Payment failed for play_session: ${request.sessionId}, from platform: ${request.platform}, \n\t with code: ${e.decline_code} \n\t and message: ${e.message}.")
         cloudWatchMetrics.logPaymentFailure(PaymentProvider.Stripe, request.platform)
         BadRequest(Json.toJson(e)).withHeaders(corsHeaders(request): _*)
       }

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -39,7 +39,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
   // THIS ENDPOINT IS USED BY BOTH THE FRONTEND AND THE MOBILE-APP
   def pay = (NoCacheAction andThen MobileSupportAction andThen ABTestAction)
     .async(BodyParsers.jsonOrMultipart(ContributionRequest.contributionForm)) { implicit request =>
-    info(s"A Stripe payment is being attempted with contributions_session id: ${request.sessionId}, from platform: ${request.platform}.")
+    info(s"A Stripe payment is being attempted with contributions session id: ${request.sessionId}, from platform: ${request.platform}.")
     cloudWatchMetrics.logPaymentAttempt(PaymentProvider.Stripe, request.platform)
 
     val form = request.body
@@ -130,10 +130,10 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
 
     def logPaymentSuccess: Unit = {
       if (request.isAndroid) {
-        info(s"Stripe payment successful for contributions_session id: ${request.sessionId} - redirected to external platform for thank you page. platform is: ${request.platform}.")
+        info(s"Stripe payment successful for contributions session id: ${request.sessionId} - redirected to external platform for thank you page. platform is: ${request.platform}.")
         cloudWatchMetrics.logPaymentSuccessRedirected(PaymentProvider.Stripe, request.platform)
       } else {
-        info(s"Stripe payment successful for contributions_session id: ${request.sessionId}, from platform ${request.platform}")
+        info(s"Stripe payment successful for contributions session id: ${request.sessionId}, from platform ${request.platform}")
         cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Stripe, request.platform)
       }
     }
@@ -151,13 +151,13 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
         .withHeaders(corsHeaders(request): _*)
     }.recover {
       case e: Stripe.Error => {
-        warn(s"Payment failed for contributions_session id: ${request.sessionId}, from platform: ${request.platform}, \n\t with code: ${e.decline_code} \n\t and message: ${e.message}.")
+        warn(s"Payment failed for contributions session id: ${request.sessionId}, from platform: ${request.platform}, \n\t with code: ${e.decline_code} \n\t and message: ${e.message}.")
         cloudWatchMetrics.logPaymentFailure(PaymentProvider.Stripe, request.platform)
         BadRequest(Json.toJson(e)).withHeaders(corsHeaders(request): _*)
       }
       case _ => {
         cloudWatchMetrics.logUnhandledPaymentFailure(PaymentProvider.Stripe, request.platform)
-        warn(s"Payment failed for unknown reason. contributions_session id: ${request.sessionId}, from platform: ${request.platform}")
+        warn(s"Payment failed for unknown reason. contributions session id: ${request.sessionId}, from platform: ${request.platform}")
         BadRequest(Json.toJson("unknown error")).withHeaders(corsHeaders(request): _*)
       }
     }

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -39,7 +39,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
   // THIS ENDPOINT IS USED BY BOTH THE FRONTEND AND THE MOBILE-APP
   def pay = (NoCacheAction andThen MobileSupportAction andThen ABTestAction)
     .async(BodyParsers.jsonOrMultipart(ContributionRequest.contributionForm)) { implicit request =>
-    info(s"A Stripe payment is being attempted with payment_session id: ${request.sessionId}, from platform: ${request.platform}.")
+    info(s"A Stripe payment is being attempted with contributions_session id: ${request.sessionId}, from platform: ${request.platform}.")
     cloudWatchMetrics.logPaymentAttempt(PaymentProvider.Stripe, request.platform)
 
     val form = request.body
@@ -130,10 +130,10 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
 
     def logPaymentSuccess: Unit = {
       if (request.isAndroid) {
-        info(s"Stripe payment successful for payment_session id: ${request.sessionId} - redirected to external platform for thank you page. platform is: ${request.platform}.")
+        info(s"Stripe payment successful for contributions_session id: ${request.sessionId} - redirected to external platform for thank you page. platform is: ${request.platform}.")
         cloudWatchMetrics.logPaymentSuccessRedirected(PaymentProvider.Stripe, request.platform)
       } else {
-        info(s"Stripe payment successful for payment_session id: ${request.sessionId}, from platform ${request.platform}")
+        info(s"Stripe payment successful for contributions_session id: ${request.sessionId}, from platform ${request.platform}")
         cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Stripe, request.platform)
       }
     }
@@ -151,13 +151,13 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
         .withHeaders(corsHeaders(request): _*)
     }.recover {
       case e: Stripe.Error => {
-        warn(s"Payment failed for payment_session id: ${request.sessionId}, from platform: ${request.platform}, \n\t with code: ${e.decline_code} \n\t and message: ${e.message}.")
+        warn(s"Payment failed for contributions_session id: ${request.sessionId}, from platform: ${request.platform}, \n\t with code: ${e.decline_code} \n\t and message: ${e.message}.")
         cloudWatchMetrics.logPaymentFailure(PaymentProvider.Stripe, request.platform)
         BadRequest(Json.toJson(e)).withHeaders(corsHeaders(request): _*)
       }
       case _ => {
         cloudWatchMetrics.logUnhandledPaymentFailure(PaymentProvider.Stripe, request.platform)
-        warn(s"Payment failed for unknown reason. payment_session id: ${request.sessionId}, from platform: ${request.platform}")
+        warn(s"Payment failed for unknown reason. contributions_session id: ${request.sessionId}, from platform: ${request.platform}")
         BadRequest(Json.toJson("unknown error")).withHeaders(corsHeaders(request): _*)
       }
     }


### PR DESCRIPTION
This is a change to the logging - essentially it replaces request id with the play session id.
In addition, the id is recorded as "payment_session" field in the play session cookie. This is needed because both stripe and paypal payments have a new session id and request id for the thank-you and post payment pages, so it is very difficult to follow a payment to completion with any confidence in the current logging setup.
Note - I have kept payment hooks using the request id - this is because I don't believe that they will have a play session cookie associated with them.

Testing - I have tested both paypal and stripe flows and both work ok locally.