### PR TITLE
Stripe meta data update

### DIFF
--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -14,7 +14,7 @@ import play.api.mvc._
 import play.filters.csrf.{CSRF, CSRFAddToken}
 import services.PaymentServices
 import utils.MaxAmount
-import utils.RequestCountry._
+import utils.FastlyUtils._
 import views.support._
 
 import scala.util.Try
@@ -29,7 +29,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
 
   def contributeRedirect = (NoCacheAction andThen MobileSupportAction) { implicit request =>
 
-    val countryGroup = request.getFastlyCountry match {
+    val countryGroup = request.getFastlyCountryGroup match {
       case Some(Canada) | Some(NewZealand) | Some(RestOfTheWorld) => UK
       case Some(other) => other
       case None => UK

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -24,6 +24,7 @@ import play.api.libs.json._
 import play.api.mvc._
 import services.Ophan.OphanResponse
 import services.{OphanAcquisitionEvent, OphanService, PaymentServices}
+import utils.FastlyUtils._
 import utils.MaxAmount
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -67,7 +68,9 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
       "intcmp" -> form.intcmp.mkString,
       "refererPageviewId" -> form.refererPageviewId.mkString,
       "refererUrl" -> form.refererUrl.mkString,
-      "contributionId" -> contributionId.toString
+      "contributionId" -> contributionId.toString,
+      "countryCode" -> request.getFastlyCountryCode.getOrElse("unknown-country-code"),
+      "countrySubdivisionCode" -> request.getFastlyCountrySubdivisionCode.getOrElse("unknown-country-subdivision-code")
     ) ++ List(
       form.postcode.map("postcode" -> _),
       idUser.map("idUser" -> _.id)

--- a/app/utils/FastlyUtils.scala
+++ b/app/utils/FastlyUtils.scala
@@ -3,10 +3,17 @@ package utils
 import com.gu.i18n.CountryGroup
 import play.api.mvc.Request
 
-object RequestCountry {
-  implicit class RequestWithFastlyCountry(r: Request[_]) {
-    def getFastlyCountry = r.headers.get("X-GU-GeoIP-Country-Code").flatMap(CountryGroup.byFastlyCountryCode)
+object FastlyUtils {
+
+  implicit class FastlyRequest(r: Request[_]) {
+
+    def getFastlyCountryCode: Option[String] = r.headers.get("X-GU-GeoIP-Country-Code")
+
+    def getFastlyCountryGroup: Option[CountryGroup] = getFastlyCountryCode.flatMap(CountryGroup.byFastlyCountryCode)
+
+    def getFastlyCountrySubdivisionCode: Option[String] = r.headers.get("GU-ISO-3166-2")
   }
+
   implicit class AuthenticatedRequestWithIdentity(r:/*Auth*/Request[_])
   {
     def getIdentityCountryGroup = CountryGroup.UK


### PR DESCRIPTION
Country code and country subdivision code added to the the Stripe meta data. This allows contributions in the US to be audited by state. See corresponding [code](https://manage.fastly.com/configure/services/14OHcjf7ueXm1ilie2wY00/versions/13/contents) and [production](https://manage.fastly.com/configure/services/3eAImrcMhkiYNBpDzEIpbx/versions/10/contents) configurations in Fastly.


Here is a fragment from the Stripe Dashboard. The record was created by using a Stripe test card on CODE.

<img width="944" alt="stripe-meta-data" src="https://user-images.githubusercontent.com/4085817/29933499-bbeb9aa4-8e6f-11e7-926f-55cfb6b8e7ba.png">

Have you gone through the contributions flow for all test variants ? __Yes, tested on CODE with Stripe and Paypal test accounts__
