### PR TITLE
Allow test username to be passed as a query parameter

### DIFF
--- a/app/services/PaymentServices.scala
+++ b/app/services/PaymentServices.scala
@@ -67,7 +67,8 @@ class PaymentServices(
   }
 
   private def isTestUser(request: RequestHeader): Boolean =
-    request.cookies.get("_test_username").map(_.value)
+    request.getQueryString("_test_username")
+      .orElse(request.cookies.get("_test_username").map(_.value))
       .orElse(authProvider(request).flatMap(_.displayName))
       .exists(testUsernames.isValid)
 


### PR DESCRIPTION
This will make it easier to support test users in support-frontend without needing to add CSRF complexity associated with cookies

Have you gone through the contributions flow for all test variants ?

No
