### PR TITLE
Add support.code.dev-theguardian.com to list of allowed origins

### DIFF
--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -27,7 +27,8 @@ paypal {
 
 cors {
     allowedOrigins = [
-        "https://support.theguardian.com"
+        "https://support.theguardian.com",
+        "https://support.code.dev-theguardian.com"
     ]
 }
 


### PR DESCRIPTION
This is to enable testing from the support code environment.

Have you gone through the contributions flow for all test variants ?
No