### PR TITLE
Use throwables to encode errors rather than strings in DB access

### DIFF
--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -113,7 +113,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
       )
     }
 
-    def storeMetaData(metadata: stripe.StripeMetaData): EitherT[Future, String, SavedContributionData] = {
+    def storeMetaData(metadata: stripe.StripeMetaData): EitherT[Future, Throwable, SavedContributionData] = {
       stripe.storeMetaData(
         created = metadata.contributionMetadata.created,
         name = form.name,

--- a/app/data/ContributionData.scala
+++ b/app/data/ContributionData.scala
@@ -16,15 +16,15 @@ import scala.util.Try
 
 class ContributionData(db: Database)(implicit ec: ExecutionContext) extends TagAwareLogger {
 
-  def withAsyncConnection[A](autocommit: Boolean = false)(block: Connection => A)(implicit tags: LoggingTags): EitherT[Future, String, A] = EitherT(Future {
+  def withAsyncConnection[A](autocommit: Boolean = false)(block: Connection => A)(implicit tags: LoggingTags): EitherT[Future, Throwable, A] = EitherT(Future {
     val result = Try(db.withConnection(autocommit)(block))
     Either.fromTry(result).leftMap { exception =>
       error("Error encountered during the execution of the sql query", exception)
-      "Error encountered during the execution of the sql query"
+      exception
     }
   })
 
-  def insertPaymentHook(paymentHook: PaymentHook)(implicit tags: LoggingTags): EitherT[Future, String, PaymentHook] = {
+  def insertPaymentHook(paymentHook: PaymentHook)(implicit tags: LoggingTags): EitherT[Future, Throwable, PaymentHook] = {
     withAsyncConnection(autocommit = true) { implicit conn =>
       val request = SQL"""
         INSERT INTO payment_hooks(
@@ -63,7 +63,7 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) extends TagA
     }
   }
 
-  def insertPaymentMetaData(pmd: ContributionMetaData)(implicit tags: LoggingTags): EitherT[Future, String, ContributionMetaData] = {
+  def insertPaymentMetaData(pmd: ContributionMetaData)(implicit tags: LoggingTags): EitherT[Future, Throwable, ContributionMetaData] = {
     withAsyncConnection(autocommit = true) { implicit conn =>
       val request = SQL"""
         INSERT INTO contribution_metadata(
@@ -111,7 +111,7 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) extends TagA
     }
   }
 
-  def saveContributor(contributor: Contributor)(implicit tags: LoggingTags): EitherT[Future, String, Contributor] = {
+  def saveContributor(contributor: Contributor)(implicit tags: LoggingTags): EitherT[Future, Throwable, Contributor] = {
     withAsyncConnection(autocommit = true) { implicit conn =>
       // Note that the contributor ID will only set on insert. it's not touched on update.
       val request = SQL"""

--- a/app/models/PaypalApiError.scala
+++ b/app/models/PaypalApiError.scala
@@ -22,10 +22,9 @@ object PaypalErrorType extends Enum[PaypalErrorType] with PlayJsonEnum[PaypalErr
   }
 }
 
-case class PaypalApiError(
-  errorType: PaypalErrorType,
-  message: String
-)
+case class PaypalApiError(errorType: PaypalErrorType, message: String) extends Exception {
+  override def getMessage: String = s"PaypalApiError of type $errorType: $message"
+}
 
 object PaypalApiError {
   def fromString(message: String): PaypalApiError = PaypalApiError(PaypalErrorType.Other, message)

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -188,7 +188,7 @@ class PaypalService(
     idUser: Option[IdentityId],
     platform: Option[String],
     ophanVisitId: Option[String]
-  )(implicit tags: LoggingTags): EitherT[Future, String, SavedContributionData] = {
+  )(implicit tags: LoggingTags): EitherT[Future, Throwable, SavedContributionData] = {
 
     val contributionDataToSave = for {
       transaction <- attempt("get transaction")(payment.getTransactions.asScala.head)
@@ -252,18 +252,18 @@ class PaypalService(
     }
 
     for {
-      data <- contributionDataToSave.leftMap(_.message)
+      data <- contributionDataToSave.leftMap(identity[Throwable])
       (contributor, contributionMetaData, contributorRow) = data
       contributionMetaData <- contributionData.insertPaymentMetaData(contributionMetaData)
       contributor <- contributionData.saveContributor(contributor)
-      _ <- emailService.thank(contributorRow).leftMap(e => e.getMessage)
+      _ <- emailService.thank(contributorRow)
     } yield SavedContributionData(
       contributor = contributor,
       contributionMetaData = contributionMetaData
     )
   }
 
-  def updateMarketingOptIn(email: String, marketingOptInt: Boolean, idUser: Option[IdentityId])(implicit tags: LoggingTags): EitherT[Future, String, Contributor] = {
+  def updateMarketingOptIn(email: String, marketingOptInt: Boolean, idUser: Option[IdentityId])(implicit tags: LoggingTags): EitherT[Future, Throwable, Contributor] = {
     val contributor = Contributor(
       email = email,
       contributorId = None,
@@ -288,7 +288,7 @@ class PaypalService(
     Event.validateReceivedEvent(context, headers.asJava, body)
   }
 
-  def processPaymentHook(paypalHook: PaypalHook)(implicit tags: LoggingTags): EitherT[Future, String, PaymentHook] = {
+  def processPaymentHook(paypalHook: PaypalHook)(implicit tags: LoggingTags): EitherT[Future, Throwable, PaymentHook] = {
 
     def contributionIdFromPaypal(paymentId: String): ContributionId = {
       val payment = Payment.get(apiContext, paypalHook.paymentId)

--- a/app/services/StripeService.scala
+++ b/app/services/StripeService.scala
@@ -94,7 +94,7 @@ class StripeService(
     contributorRow: ContributorRow,
     idUser: Option[IdentityId],
     marketing: Boolean)
-    (implicit tags: LoggingTags): EitherT[Future, String, SavedContributionData] = {
+    (implicit tags: LoggingTags): EitherT[Future, Throwable, SavedContributionData] = {
 
     // Fire and forget: we don't want to stop the user flow
     idUser.foreach { id =>
@@ -111,7 +111,7 @@ class StripeService(
     )
   }
 
-  def processPaymentHook(stripeHook: StripeHook)(implicit tags: LoggingTags): EitherT[Future, String, PaymentHook] = {
+  def processPaymentHook(stripeHook: StripeHook)(implicit tags: LoggingTags): EitherT[Future, Throwable, PaymentHook] = {
 
     def convertedAmount(event: Event[Charge]): OptionT[Future, BigDecimal] = {
       for {
@@ -132,7 +132,7 @@ class StripeService(
     } yield paymentHook
 
     for {
-      hook <- paymentHook.toRight(s"Unable to find the stripe event identified by ${stripeHook.eventId}")
+      hook <- paymentHook.toRight[Throwable](new RuntimeException(s"Unable to find the stripe event identified by ${stripeHook.eventId}"))
       insertResult <- contributionData.insertPaymentHook(hook)
     } yield insertResult
   }

--- a/test/controllers/PaypalControllerSpec.scala
+++ b/test/controllers/PaypalControllerSpec.scala
@@ -70,7 +70,7 @@ class PaypalControllerFixture(implicit ec: ExecutionContext) extends MockitoSuga
     platform = Matchers.any[Option[String]],
     ophanVisitId = Matchers.any[Option[String]]
   )(Matchers.any[LoggingTags]))
-    .thenReturn(EitherT.pure[Future, String, SavedContributionData](mock[SavedContributionData]))
+    .thenReturn(EitherT.pure[Future, Throwable, SavedContributionData](mock[SavedContributionData]))
 
   val controller: PaypalController = new PaypalController(mockPaymentServices, mockCorsConfig, supportConfig, mockCsrfCheck, mockCloudwatchMetrics)
 
@@ -218,7 +218,7 @@ class PaypalControllerSpec extends PlaySpec
           platform = Matchers.any[Option[String]],
           ophanVisitId = Matchers.any[Option[String]]
         )(Matchers.any[LoggingTags]))
-          .thenReturn(EitherT.left[Future, String, SavedContributionData](Future.successful("Error")))
+          .thenReturn(EitherT.left[Future, Throwable, SavedContributionData](Future.successful(new RuntimeException("Error"))))
       }
 
 


### PR DESCRIPTION
This pull request uses throwables to encode errors rather than strings for data base access. This means that it is easier to combine such return types with the custom `PaypalAPIError` (introduced in #325) in a monadic context. This composition will be used when fixing issue #336.
