### PR TITLE
Ophan service logging improved

### DIFF
--- a/app/models/PaypalAcquisitionComponents.scala
+++ b/app/models/PaypalAcquisitionComponents.scala
@@ -2,7 +2,6 @@ package models
 
 import abtests.Allocation
 import actions.CommonActions.ABTestRequest
-import com.gu.acquisition.services.OphanServiceError
 import com.paypal.api.payments.Payment
 import controllers.httpmodels.CaptureRequest
 import ophan.thrift.componentEvent.ComponentType
@@ -33,7 +32,7 @@ object PaypalAcquisitionComponents {
     implicit object paypalAcquisitionSubmissionBuilder
       extends AcquisitionSubmissionBuilder[Execute] with AcquisitionSubmissionBuilderUtils {
 
-      def buildOphanIds(components: Execute): Either[OphanServiceError, OphanIds] = {
+      def buildOphanIds(components: Execute): Either[String, OphanIds] = {
         import components._
         for {
           browserId <- tryField("ophanBrowserId")(request.ophanBrowserId.get)
@@ -41,7 +40,7 @@ object PaypalAcquisitionComponents {
         } yield OphanIds(browserId, pageviewId, request.ophanVisitId)
       }
 
-      def buildAcquisition(components: Execute): Either[OphanServiceError, Acquisition] = {
+      def buildAcquisition(components: Execute): Either[String, Acquisition] = {
         import components._
         for {
           amount <- tryField("amount")(payment.getPaymentInstruction.getAmount.getValue.toDouble)
@@ -74,7 +73,7 @@ object PaypalAcquisitionComponents {
     implicit object paypalAcquisitionSubmissionBuilder
       extends AcquisitionSubmissionBuilder[Capture] with AcquisitionSubmissionBuilderUtils {
 
-      override def buildOphanIds(components: Capture): Either[OphanServiceError, OphanIds] = {
+      override def buildOphanIds(components: Capture): Either[String, OphanIds] = {
         import components._
         for {
           browserId <- tryField("ophanBrowserId")(request.body.ophanBrowserId.get)
@@ -82,7 +81,7 @@ object PaypalAcquisitionComponents {
         } yield OphanIds(browserId, pageviewId, visitId = None)
       }
 
-      override def buildAcquisition(components: Capture): Either[OphanServiceError, Acquisition] = {
+      override def buildAcquisition(components: Capture): Either[String, Acquisition] = {
         import components._
 
         for {

--- a/app/models/StripeAcquisitionComponents.scala
+++ b/app/models/StripeAcquisitionComponents.scala
@@ -1,7 +1,6 @@
 package models
 
 import actions.CommonActions.ABTestRequest
-import com.gu.acquisition.services.OphanServiceError
 import com.gu.stripe.Stripe.Charge
 import controllers.forms.ContributionRequest
 import ophan.thrift.event.{Acquisition, PaymentFrequency, Product}
@@ -14,7 +13,7 @@ object StripeAcquisitionComponents {
   implicit object stripeAcquisitionSubmissionBuilder
     extends AcquisitionSubmissionBuilder[StripeAcquisitionComponents] with AcquisitionSubmissionBuilderUtils {
 
-    override def buildAcquisition(components: StripeAcquisitionComponents): Either[OphanServiceError, Acquisition] = {
+    override def buildAcquisition(components: StripeAcquisitionComponents): Either[String, Acquisition] = {
       import components._
       Either.right(
         Acquisition(
@@ -36,7 +35,7 @@ object StripeAcquisitionComponents {
       )
     }
 
-    def buildOphanIds(components: StripeAcquisitionComponents): Either[OphanServiceError, OphanIds] = {
+    def buildOphanIds(components: StripeAcquisitionComponents): Either[String, OphanIds] = {
       import components._
       tryField("ophanBrowserId")(request.body.ophanBrowserId.get)
         .map { browserId =>

--- a/app/services/ContributionOphanService.scala
+++ b/app/services/ContributionOphanService.scala
@@ -76,7 +76,7 @@ class ProdContributionOphanService(implicit system: ActorSystem, materializer: A
 object ContributionOphanService {
 
   def apply(env: Environment)(implicit system: ActorSystem, mat: ActorMaterializer): ContributionOphanService =
-    if(env.mode == Mode.Prod) new ProdContributionOphanService else NonProdContributionOphanService
+    if (env.mode == Mode.Prod) new ProdContributionOphanService else NonProdContributionOphanService
 
   case class OphanIds(browserId: String, viewId: String, visitId: Option[String])
 

--- a/app/services/ContributionOphanService.scala
+++ b/app/services/ContributionOphanService.scala
@@ -6,7 +6,7 @@ import akka.stream.ActorMaterializer
 import cats.data.EitherT
 import cats.syntax.EitherSyntax
 import cats.syntax.either._
-import com.gu.acquisition.services.{OphanService, OphanServiceError}
+import com.gu.acquisition.services.OphanService
 import monitoring.{LoggingTags, TagAwareLogger}
 import ophan.thrift.event.{AbTestInfo, Acquisition}
 import play.api.mvc.Request

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -71,7 +71,7 @@ trait AppComponents extends PlayComponents with GzipFilterComponents {
   lazy val identityService = new IdentityService(wsClient, idConfig)
   lazy val emailService = wire[EmailService]
 
-  lazy val ophanService = new ContributionOphanService(environment)
+  lazy val ophanService = ContributionOphanService(environment)
   lazy val giraffeController = wire[Contributions]
   lazy val healthcheckController = wire[Healthcheck]
   lazy val assetController = wire[Assets]

--- a/test/controllers/PaypalControllerSpec.scala
+++ b/test/controllers/PaypalControllerSpec.scala
@@ -101,6 +101,7 @@ class PaypalControllerFixture(implicit ec: ExecutionContext) extends MockitoSuga
     Mockito.verify(mockOphanService, VerificationModeFactory.times(times))
       .submitAcquisition[Any](Matchers.any[Any])(
         Matchers.any[AcquisitionSubmissionBuilder[Any]],
+        Matchers.any[ClassTag[Any]],
         Matchers.any[ExecutionContext],
         Matchers.any[LoggingTags],
         Matchers.any[Request[_]]


### PR DESCRIPTION
cc @guardian/contributions 

Implements different service for prod and non-prod which makes the logging easier to reason about.

This will facilitate getting #341 over the line.

Have you gone through the contributions flow for all test variants ? __Yes, locally__
