### PR TITLE
Fix custom session id

### DIFF
--- a/app/abtests/Test.scala
+++ b/app/abtests/Test.scala
@@ -1,6 +1,6 @@
 package abtests
 
-import actions.CommonActions.ABTestRequest
+import actions.CommonActions.MetaDataRequest
 import com.github.slugify.Slugify
 import com.gu.acquisition.utils.AbTestConverter
 import play.api.db.Database

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -44,7 +44,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
     }
   }
 
-  def capturePayment = (NoCacheAction andThen ABTestAction).async(parse.json[CaptureRequest]) { implicit request =>
+  def capturePayment = NoCacheAction.andThen(MetaDataAction.default).async(parse.json[CaptureRequest]) { implicit request =>
     val captureBody = request.body
     val paypalService: PaypalService = paymentServices.paypalServiceFor(request)
 
@@ -112,7 +112,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
     source: Option[AcquisitionSource],
     abTest: Option[AbTest],
     supportRedirect: Option[Boolean]
-  ) = (NoCacheAction andThen MobileSupportAction andThen ABTestAction).async { implicit request =>
+  ) = NoCacheAction.andThen(MobileSupportAction).andThen(MetaDataAction.default).async { implicit request =>
     val paypalService = paymentServices.paypalServiceFor(request)
 
     info(s"Attempting paypal payment for contributions session id: ${request.sessionId}")
@@ -190,7 +190,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
   private def capAmount(amount: BigDecimal, currency: Currency): BigDecimal = amount min MaxAmount.forCurrency(currency)
 
   def authorize = checkToken {
-    NoCacheAction.async(parse.json[AuthRequest]) { implicit request =>
+    NoCacheAction.andThen(MetaDataAction.default).async(parse.json[AuthRequest]) { implicit request =>
       info(s"Attempting to obtain paypal auth response. Contributions session id: ${request.sessionId}. Platform: ${request.platform}.")
       cloudWatchMetrics.logPaymentAuthAttempt(PaymentProvider.Paypal, request.platform)
       val authRequest = request.body

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -37,7 +37,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
   }
 
   // THIS ENDPOINT IS USED BY BOTH THE FRONTEND AND THE MOBILE-APP
-  def pay = (NoCacheAction andThen MobileSupportAction andThen ABTestAction)
+  def pay = NoCacheAction.andThen(MobileSupportAction).andThen(MetaDataAction.default)
     .async(parse.json[ContributionRequest]) { implicit request =>
     info(s"A Stripe payment is being attempted with contributions session id: ${request.sessionId}, from platform: ${request.platform}.")
     cloudWatchMetrics.logPaymentAttempt(PaymentProvider.Stripe, request.platform)

--- a/app/models/PaypalAcquisitionComponents.scala
+++ b/app/models/PaypalAcquisitionComponents.scala
@@ -1,7 +1,7 @@
 package models
 
 import abtests.Allocation
-import actions.CommonActions.ABTestRequest
+import actions.CommonActions.MetaDataRequest
 import com.paypal.api.payments.Payment
 import controllers.httpmodels.CaptureRequest
 import ophan.thrift.componentEvent.ComponentType
@@ -83,7 +83,7 @@ object PaypalAcquisitionComponents {
     }
   }
 
-  case class Capture(payment: Payment, request: ABTestRequest[CaptureRequest])
+  case class Capture(payment: Payment, request: MetaDataRequest[CaptureRequest])
 
   object Capture {
 

--- a/app/models/StripeAcquisitionComponents.scala
+++ b/app/models/StripeAcquisitionComponents.scala
@@ -1,12 +1,12 @@
 package models
 
-import actions.CommonActions.ABTestRequest
+import actions.CommonActions.MetaDataRequest
 import com.gu.stripe.Stripe.Charge
 import controllers.forms.ContributionRequest
 import ophan.thrift.event.{Acquisition, PaymentFrequency, Product}
 import services.ContributionOphanService.{ContributionAcquisitionSubmissionBuilder, OphanIds}
 
-case class StripeAcquisitionComponents(charge: Charge, request: ABTestRequest[ContributionRequest])
+case class StripeAcquisitionComponents(charge: Charge, request: MetaDataRequest[ContributionRequest])
 
 object StripeAcquisitionComponents {
 

--- a/app/services/ContributionOphanService.scala
+++ b/app/services/ContributionOphanService.scala
@@ -1,6 +1,7 @@
 package services
 
 import abtests.Allocation
+import actions.CommonActions.MetaDataRequest
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import cats.data.EitherT
@@ -9,7 +10,6 @@ import cats.syntax.either._
 import com.gu.acquisition.services.OphanService
 import monitoring.{LoggingTags, TagAwareLogger}
 import ophan.thrift.event.{AbTest, AbTestInfo, Acquisition}
-import play.api.mvc.Request
 import play.api.{Environment, Mode}
 import services.ContributionOphanService.{AcquisitionSubmission, AcquisitionSubmissionBuilder}
 import simulacrum.typeclass
@@ -22,7 +22,7 @@ trait ContributionOphanService {
   def submitAcquisition[A : AcquisitionSubmissionBuilder : ClassTag](a: A)(
     implicit ec: ExecutionContext,
     tags: LoggingTags,
-    request: Request[_]
+    request: MetaDataRequest[_]
   ): EitherT[Future, String, AcquisitionSubmission]
 }
 
@@ -36,7 +36,7 @@ object NonProdContributionOphanService extends ContributionOphanService with Tag
   def submitAcquisition[A : AcquisitionSubmissionBuilder : ClassTag](a: A)(
     implicit ec: ExecutionContext,
     tags: LoggingTags,
-    request: Request[_]
+    request: MetaDataRequest[_]
   ): EitherT[Future, String, AcquisitionSubmission] =
     EitherT.fromEither[Future](a.asAcquisitionSubmission).bimap(
       err => {
@@ -66,7 +66,7 @@ class ProdContributionOphanService(implicit system: ActorSystem, materializer: A
   def submitAcquisition[A : AcquisitionSubmissionBuilder : ClassTag](a: A)(
     implicit ec: ExecutionContext,
     tags: LoggingTags,
-    request: Request[_]
+    request: MetaDataRequest[_]
   ): EitherT[Future, String, AcquisitionSubmission] =
     EitherT.fromEither[Future](a.asAcquisitionSubmission).flatMap(sendSubmission)
       .bimap(

--- a/app/views/support/PageInfo.scala
+++ b/app/views/support/PageInfo.scala
@@ -1,6 +1,6 @@
 package views.support
 
-import actions.CommonActions.ABTestRequest
+import actions.CommonActions.MetaDataRequest
 
 case class PageInfo(
   title: String = "Support the Guardian",

--- a/test/controllers/PaypalControllerSpec.scala
+++ b/test/controllers/PaypalControllerSpec.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import abtests.Allocation
+import actions.CommonActions.MetaDataRequest
 import akka.stream.Materializer
 import cats.data.EitherT
 import com.gu.i18n.{CountryGroup, GBP}
@@ -104,7 +105,7 @@ class PaypalControllerFixture(implicit ec: ExecutionContext) extends MockitoSuga
         Matchers.any[ClassTag[Any]],
         Matchers.any[ExecutionContext],
         Matchers.any[LoggingTags],
-        Matchers.any[Request[_]]
+        Matchers.any[MetaDataRequest[_]]
       )
 }
 


### PR DESCRIPTION
cc @guardian/contributions 

Currently we are using the signature of the Play session cookie as the session id - not good for providing a unique id per user session.

The solution is to generate a unique id and then persist it across requests using the Play session cookie via an action builder. 

For simplicity, I've added to (and renamed) the pre-existing `AbTestAction` builder, rather than create a new one and compose them.

_Have you gone through the contributions flow for all test variants ?_ __Yes, on CODE__
