### PR TITLE
AB tests not sent as part of acquisition submission (for now)

### DIFF
--- a/app/services/ContributionOphanService.scala
+++ b/app/services/ContributionOphanService.scala
@@ -122,9 +122,13 @@ object ContributionOphanService {
       }
 
     protected def abTestInfo(native: Set[Allocation], nonNative: Option[AbTest]): AbTestInfo = {
-      import com.gu.acquisition.syntax._
-      val abTestInfo = native.asAbTestInfo
-      nonNative.map(abTest => AbTestInfo(abTestInfo.tests + abTest)).getOrElse(abTestInfo)
+      // TODO: re-instate the 'correct' implementation once we have verified that acquisition events are not being sent
+      // because the underlying Ophan client is incorrectly formatting Ab tests.
+
+      // import com.gu.acquisition.syntax._
+      // val abTestInfo = native.asAbTestInfo
+      // nonNative.map(abTest => AbTestInfo(abTestInfo.tests + abTest)).getOrElse(abTestInfo)
+      AbTestInfo()
     }
   }
 }


### PR DESCRIPTION
Acquisition events are currently not reaching the end of the data pipeline. We believe this is because the [acquisition event producer](https://github.com/guardian/acquisition-event-producer) is incorrectly formatting AB tests. As no one in the team is in today with authorisation to publish to bintray, we are taking the pragmatic approach of removing AB tests from the acquisition event as a way of validating this is indeed the issue.

Have you gone through the contributions flow for all test variants ? __No__
