### PR TITLE
Handle error thrown when parsing invalid JSON

### DIFF
--- a/app/utils/ThriftUtils.scala
+++ b/app/utils/ThriftUtils.scala
@@ -92,7 +92,7 @@ object ThriftUtils {
     // Query string bindable type classes
 
     implicit def thriftEnumQueryStringBindable[A : ClassTag](implicit F: ThriftEnumFormatter[A]): QueryStringBindable[A] =
-      queryStringBindableInstance(F.decode(_).toOption, F.encode)
+      queryStringBindableInstance(F.decode(_).leftMap(_.message), F.encode)
 
     implicit val abTestQueryStringBindable: QueryStringBindable[AbTest] =
       queryStringBindableInstanceFromFormat[AbTest]


### PR DESCRIPTION
I didn't realise that `Json.parse()` didn't encode the error in the result. As noted by @joelochlann , this resulted in an error page (screenshot below) if the value of `acquisitionData` in the query string was not valid JSON (__although no user saw this as we currently aren't using this query string field__).

<img width="1212" alt="error" src="https://user-images.githubusercontent.com/4085817/30645796-c127a554-9e0e-11e7-9889-215daf12b987.png">

This pull request fixes this issue.

Have you gone through the contributions flow for all test variants ? __Yes, locally__
