### PR TITLE
Add support for regional Stripe configurations

### DIFF
--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -63,6 +63,8 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
 
       val errorMessage = error.map(_.message)
 
+      val regionalStripePublicKeys = paymentServices.stripeKeysFor(request)
+
       val acquisitionData = ReferrerAcquisitionData.fromQueryString(request.queryString)
         // When mobile starts sending acquisition data we will want to warn in all cases.
         .leftMap(err => if (!request.isMobile) warn(s"$err - contributions session id: ${request.sessionId}"))
@@ -80,7 +82,8 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
         title = "Support the Guardian | Contribute today",
         url = request.path,
         image = Some(Asset.absoluteUrl("images/twitter-card.png")),
-        stripePublicKeys = paymentServices.stripeKeysFor(request),
+        stripePublicKey = Some(regionalStripePublicKeys(countryGroup)),
+        regionalStripePublicKeys = regionalStripePublicKeys,
         description = Some("By making a contribution, you’ll be supporting independent journalism that speaks truth to power"),
         customSignInUrl = Some((Config.idWebAppUrl / "signin") ? ("skipConfirmation" -> "true"))
       )

--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -49,7 +49,6 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       title = "Support the Guardian | Contribute today",
       url = request.path,
       image = Some(Asset.absoluteUrl("images/twitter-card.png")),
-      stripePublicKey = None,
       description = Some("By making a contribution, you’ll be supporting independent journalism that speaks truth to power"),
       customSignInUrl = Some((Config.idWebAppUrl / "signin") ? ("skipConfirmation" -> "true"))
     )
@@ -63,7 +62,6 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
       import cats.syntax.either._
 
       val errorMessage = error.map(_.message)
-      val stripe = paymentServices.stripeServiceFor(request)
 
       val acquisitionData = ReferrerAcquisitionData.fromQueryString(request.queryString)
         // When mobile starts sending acquisition data we will want to warn in all cases.
@@ -82,7 +80,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
         title = "Support the Guardian | Contribute today",
         url = request.path,
         image = Some(Asset.absoluteUrl("images/twitter-card.png")),
-        stripePublicKey = Some(stripe.publicKey),
+        stripePublicKeys = paymentServices.stripeKeysFor(request),
         description = Some("By making a contribution, you’ll be supporting independent journalism that speaks truth to power"),
         customSignInUrl = Some((Config.idWebAppUrl / "signin") ? ("skipConfirmation" -> "true"))
       )

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -194,7 +194,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
 
       withParsedStripeHook(request.body) { stripeHook =>
         val countryGroup: Option[CountryGroup] = CountryGroup.byFastlyCountryCode(stripeHook.fastlyCountryCode)
-        val stripeService = paymentServices.stripeServices(countryGroup)(stripeHook.mode)
+        val stripeService = paymentServices.stripeServiceForGroup(countryGroup)(stripeHook.mode)
 
         stripeService.processPaymentHook(stripeHook)
           .value.map {

--- a/app/models/PaymentHook.scala
+++ b/app/models/PaymentHook.scala
@@ -133,7 +133,8 @@ case class StripeHook(
   currency: String,
   amount: BigDecimal,
   status: PaymentStatus,
-  email: String
+  email: String,
+  fastlyCountryCode: String
 )
 
 object StripeHook {
@@ -152,6 +153,7 @@ object StripeHook {
         status <- (payload \ "status").validate[PaymentStatus](PaymentStatus.stripeReads)
         email <- (metadata \ "email").validate[String]
         refunded <- (payload \ "refunded").validate[Boolean]
+        fastlyCountryCode <- (metadata \ "countryCode").validate[String]
       } yield {
         StripeHook(
           contributionId = contributionId,
@@ -162,7 +164,8 @@ object StripeHook {
           currency = currency.toUpperCase,
           amount = BigDecimal(amount, 2),
           status = if (refunded) Refunded else status,
-          email = email
+          email = email,
+          fastlyCountryCode = fastlyCountryCode
         )
       }
     }

--- a/app/services/PaymentServices.scala
+++ b/app/services/PaymentServices.scala
@@ -62,5 +62,5 @@ class PaymentServices(
 
   def stripeKeysFor(requestHeader: RequestHeader): Map[CountryGroup, String] =
     regionalStripeService.regionalServicesFor(modeFor(requestHeader)).mapValues(_.publicKey)
-
+      .withDefaultValue(regionalStripeService.defaultService.publicKey)
 }

--- a/app/services/RegionalStripeService.scala
+++ b/app/services/RegionalStripeService.scala
@@ -11,12 +11,12 @@ import scala.concurrent.ExecutionContext
 
 trait RegionalStripeService {
 
-  def defaultCountryGroup = CountryGroup.UK
+  def defaultService: StripeService
 
   def regionalServicesFor(mode: PaymentMode): Map[CountryGroup, StripeService]
 
-  def serviceFor(mode: PaymentMode, countryGroup: Option[CountryGroup]): StripeService =
-    regionalServicesFor(mode)(countryGroup.getOrElse(defaultCountryGroup))
+  def serviceFor(mode: PaymentMode, countryGroup: Option[CountryGroup]): StripeService
+
 }
 
 class DefaultRegionalStripeService(config: Config,
@@ -70,5 +70,12 @@ class DefaultRegionalStripeService(config: Config,
     }.toMap
   }
 
-  override def regionalServicesFor(mode: PaymentMode) = stripeServices(mode)
+  override def defaultService: StripeService =
+    regionalServicesFor(PaymentMode.Default)(CountryGroup.UK)
+
+  override def regionalServicesFor(mode: PaymentMode) =
+    stripeServices(mode)
+
+  override def serviceFor(mode: PaymentMode, countryGroup: Option[CountryGroup]): StripeService =
+    countryGroup.map(group => regionalServicesFor(mode)(group)).getOrElse(defaultService)
 }

--- a/app/services/RegionalStripeService.scala
+++ b/app/services/RegionalStripeService.scala
@@ -1,0 +1,74 @@
+package services
+
+import com.gu.i18n.CountryGroup
+import com.gu.monitoring.ServiceMetrics
+import com.gu.stripe.{StripeApiConfig, StripeCredentials}
+import com.typesafe.config.Config
+import data.ContributionData
+import models.PaymentMode
+
+import scala.concurrent.ExecutionContext
+
+trait RegionalStripeService {
+
+  def defaultCountryGroup = CountryGroup.UK
+
+  def regionalServicesFor(mode: PaymentMode): Map[CountryGroup, StripeService]
+
+  def serviceFor(mode: PaymentMode, countryGroup: Option[CountryGroup]): StripeService =
+    regionalServicesFor(mode)(countryGroup.getOrElse(defaultCountryGroup))
+}
+
+class DefaultRegionalStripeService(config: Config,
+                                   contributionDataPerMode: Map[PaymentMode, ContributionData],
+                                   identityService: IdentityService,
+                                   emailService: EmailService)(implicit ec: ExecutionContext)
+  extends RegionalStripeService {
+
+  import utils.ConfigUtils._
+
+  private val stripeConfig = config.getConfig("stripe")
+
+  // map country groups to configs (only in instances where there is a config for the country group's ID)
+  private val countryGroupConfigs: Map[CountryGroup, Config] = {
+    CountryGroup.allGroups.map { group =>
+      group -> stripeConfig.getOptionalConfig(s"keys.${group.id.toLowerCase}")
+    }.collect { case (group, Some(config)) => group -> config }.toMap
+  }
+
+  private def modeName(mode: PaymentMode): String =
+    stripeConfig.getString(mode.entryName.toLowerCase)
+
+  private def credentialsFor(mode: PaymentMode, config: Config): StripeCredentials = {
+    val keys: Config = config.getConfig(modeName(mode))
+
+    StripeCredentials(
+      secretKey = keys.getString("secret"),
+      publicKey = keys.getString("public")
+    )
+  }
+
+  private def stripeServiceFor(countryGroup: CountryGroup, mode: PaymentMode): StripeService = {
+    val config: Config = countryGroupConfigs.get(countryGroup).getOrElse(stripeConfig.getConfig(s"keys.default"))
+    val stripeMode: String = modeName(mode)
+    val credentials: StripeCredentials = credentialsFor(mode, config)
+
+    val metrics = new ServiceMetrics(stripeMode, "giraffe", "stripe")
+
+    new StripeService(
+      apiConfig = StripeApiConfig(stripeMode, credentials),
+      metrics = metrics,
+      contributionData = contributionDataPerMode(mode),
+      identityService = identityService,
+      emailService = emailService
+    )
+  }
+
+  private val stripeServices: Map[PaymentMode, Map[CountryGroup, StripeService]] = {
+    PaymentMode.values.map { mode =>
+      mode -> CountryGroup.allGroups.map(group => group -> stripeServiceFor(group, mode)).toMap
+    }.toMap
+  }
+
+  override def regionalServicesFor(mode: PaymentMode) = stripeServices(mode)
+}

--- a/app/utils/ConfigUtils.scala
+++ b/app/utils/ConfigUtils.scala
@@ -1,0 +1,11 @@
+package utils
+
+import com.typesafe.config.Config
+
+import scala.util.Try
+
+object ConfigUtils {
+  implicit class OptionalConfig(c: Config) {
+    def getOptionalConfig(path: String): Option[Config] = Try(c.getConfig(path)).toOption
+  }
+}

--- a/app/utils/FastlyUtils.scala
+++ b/app/utils/FastlyUtils.scala
@@ -1,11 +1,11 @@
 package utils
 
 import com.gu.i18n.CountryGroup
-import play.api.mvc.Request
+import play.api.mvc.{Request, RequestHeader}
 
 object FastlyUtils {
 
-  implicit class FastlyRequest(r: Request[_]) {
+  implicit class FastlyRequest(r: RequestHeader) {
 
     def getFastlyCountryCode: Option[String] = r.headers.get("X-GU-GeoIP-Country-Code")
 

--- a/app/views/fragments/global/controlNavigation.scala.html
+++ b/app/views/fragments/global/controlNavigation.scala.html
@@ -76,7 +76,7 @@
                             class="nav-popup__link"
                             data-country-group="@Json.toJson(countryGroup)"
                             data-max-amount="@MaxAmount.forCurrency(countryGroup.currency)"
-                            data-stripe-key="@pageInfo.stripePublicKeys.get(countryGroup)">
+                            data-stripe-key="@pageInfo.regionalStripePublicKeys.get(countryGroup)">
                             @countryGroup.name (@countryGroup.currency.identifier)
                         </a>
                     </li>

--- a/app/views/fragments/global/controlNavigation.scala.html
+++ b/app/views/fragments/global/controlNavigation.scala.html
@@ -72,7 +72,13 @@
                 <ul class="nav-popup__list">
                 @for(countryGroup <- Seq(UK, Europe, US, Australia)) {
                     <li class="nav-popup__item">
-                        <a href="@routes.Contributions.contribute(countryGroup)" class="nav-popup__link" data-country-group="@Json.toJson(countryGroup)" data-max-amount="@MaxAmount.forCurrency(countryGroup.currency)">@countryGroup.name (@countryGroup.currency.identifier)</a>
+                        <a  href="@routes.Contributions.contribute(countryGroup)"
+                            class="nav-popup__link"
+                            data-country-group="@Json.toJson(countryGroup)"
+                            data-max-amount="@MaxAmount.forCurrency(countryGroup.currency)"
+                            data-stripe-key="@pageInfo.stripePublicKeys.get(countryGroup)">
+                            @countryGroup.name (@countryGroup.currency.identifier)
+                        </a>
                     </li>
                 }
                 </ul>

--- a/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -27,12 +27,9 @@
         css: {
             loaded: false
         },
-        @for(stripePublicKey <- pageInfo.stripePublicKey) {
-            stripe: {
-                key: '@stripePublicKey',
-                image: '@Asset.at("images/gu.png")'
-            },
-        }
+        stripe: {
+            image: '@Asset.at("images/gu.png")'
+        },
         membership: {
             buildNumber: '@app.BuildInfo.buildNumber',
             svgSprite: "@Asset.at("images/svg-sprite.svg")"

--- a/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -1,4 +1,5 @@
 @import views.support.PageInfo
+@import com.gu.i18n.CountryGroup
 @(pageInfo: PageInfo)
 
     @import configuration.Config
@@ -27,9 +28,12 @@
         css: {
             loaded: false
         },
+        @pageInfo.stripePublicKey.map { key =>
         stripe: {
+            defaultPublicKey: '@key',
             image: '@Asset.at("images/gu.png")'
         },
+        }
         membership: {
             buildNumber: '@app.BuildInfo.buildNumber',
             svgSprite: "@Asset.at("images/svg-sprite.svg")"

--- a/app/views/support/PageInfo.scala
+++ b/app/views/support/PageInfo.scala
@@ -9,6 +9,7 @@ case class PageInfo(
   description: Option[String] = None,
   image: Option[String] = None,
   customSignInUrl: Option[String] = None,
-  stripePublicKeys: Map[CountryGroup, String] = Map.empty,
+  stripePublicKey: Option[String] = None,
+  regionalStripePublicKeys: Map[CountryGroup, String] = Map.empty,
   kruxId: String = "JglooLwn"
 )

--- a/app/views/support/PageInfo.scala
+++ b/app/views/support/PageInfo.scala
@@ -1,6 +1,7 @@
 package views.support
 
 import actions.CommonActions.MetaDataRequest
+import com.gu.i18n.CountryGroup
 
 case class PageInfo(
   title: String = "Support the Guardian",
@@ -8,6 +9,6 @@ case class PageInfo(
   description: Option[String] = None,
   image: Option[String] = None,
   customSignInUrl: Option[String] = None,
-  stripePublicKey: Option[String] = None,
+  stripePublicKeys: Map[CountryGroup, String] = Map.empty,
   kruxId: String = "JglooLwn"
 )

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -59,11 +59,14 @@ trait AppComponents extends PlayComponents with GzipFilterComponents {
 
   lazy val testUserService = new DefaultTestUserService(identityAuthProvider, testUsernames)
 
+  lazy val regionalStripeService = new DefaultRegionalStripeService(config, contributionDataPerMode, identityService, emailService)
+
   lazy val paymentServices = new PaymentServices(
     config = config,
     testUserService = testUserService,
     identityService = identityService,
     emailService = emailService,
+    regionalStripeService = regionalStripeService,
     contributionDataPerMode = contributionDataPerMode,
     actorSystem = actorSystem
   )

--- a/assets/javascripts/src/modules/domListeners.es6
+++ b/assets/javascripts/src/modules/domListeners.es6
@@ -1,5 +1,6 @@
 import store from 'src/store';
-import {SET_DATA, SET_COUNTRY_GROUP, SET_AMOUNT, GO_FORWARD} from 'src/actions';
+import {SET_DATA, SET_COUNTRY_GROUP, SET_STRIPE_HANDLER} from 'src/actions';
+import {makeHandler} from 'src/modules/stripe';
 
 export function attachCurrencyListeners() {
     const currencyLinks = [].slice.call(document.getElementById('js-country-switcher').getElementsByTagName('a'));
@@ -20,6 +21,11 @@ export function attachCurrencyListeners() {
             data: {
                 maxAmount: parseFloat(event.target.dataset.maxAmount)
             }
+        });
+
+        store.dispatch({
+            type: SET_STRIPE_HANDLER,
+            handler: makeHandler(event.target.dataset.stripeKey)
         });
 
         heading.innerText = `${countryGroup.name} (${countryGroup.currency.symbol})`;

--- a/assets/javascripts/src/modules/stripe.es6
+++ b/assets/javascripts/src/modules/stripe.es6
@@ -8,9 +8,9 @@ export function init() {
     else initStripeJS();
 }
 
-function initStripeCheckout() {
-    const handler = StripeCheckout.configure({
-        key: guardian.stripe.key,
+export function makeHandler(key) {
+    return StripeCheckout.configure({
+        key: key,
         image: guardian.stripe.image,
         locale: 'auto',
         name: 'The Guardian',
@@ -18,19 +18,21 @@ function initStripeCheckout() {
         allowRememberMe: false,
         zipCode: false,
         token: token => {
-            store.dispatch({ type: SUBMIT_PAYMENT });
+            store.dispatch({type: SUBMIT_PAYMENT});
             processStripePayment(token);
         }
     });
+}
 
+function initStripeCheckout() {
     store.dispatch({
         type: SET_STRIPE_HANDLER,
-        handler: handler
+        handler: makeHandler(guardian.stripe.defaultPublicKey)
     });
 }
 
 function initStripeJS() {
-    Stripe.setPublishableKey(guardian.stripe.key);
+    Stripe.setPublishableKey(guardian.stripe.defaultPublicKey);
 }
 
 

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -12,8 +12,16 @@ stripe {
     testing=TEST
 
     keys {
-        TEST {
-            public = "pk_test_35RZz9AAyqErQshL410RDZMs"
+        default {
+            TEST {
+                public = "pk_test_35RZz9AAyqErQshL410RDZMs"
+            }
+        }
+
+        au {
+            TEST {
+                public = "pk_test_I1ts3iShWrjssTavL0b7QXQ6"
+            }
         }
     }
 }

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -12,12 +12,26 @@ stripe {
     testing=TEST
 
     keys {
-        TEST {
-            public = "pk_test_35RZz9AAyqErQshL410RDZMs"
+        default {
+            TEST {
+                public = "pk_test_35RZz9AAyqErQshL410RDZMs"
+            }
+
+            LIVE {
+                public = "pk_live_auSwLB4KBzbN3JOUVHvKMe6f"
+            }
         }
-        LIVE {
-            public = "pk_live_auSwLB4KBzbN3JOUVHvKMe6f"
+
+        au {
+            TEST {
+                public = "pk_test_I1ts3iShWrjssTavL0b7QXQ6"
+            }
+
+            LIVE {
+                public = "CHANGEME"
+            }
         }
+
     }
 }
 paypal {

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -28,7 +28,7 @@ stripe {
             }
 
             LIVE {
-                public = "CHANGEME"
+                public = "pk_live_HRYGcMzpbqY7ehLuUkdqvIDE"
             }
         }
 

--- a/test/models/PaymentHookSpec.scala
+++ b/test/models/PaymentHookSpec.scala
@@ -61,7 +61,8 @@ class PaymentHookSpec extends WordSpec with MustMatchers {
         currency = "GBP",
         amount = BigDecimal("25.00"),
         status = Paid,
-        email = "a@a.a"
+        email = "a@a.a",
+        fastlyCountryCode = "uk"
       )
     }
 
@@ -175,7 +176,8 @@ class PaymentHookSpec extends WordSpec with MustMatchers {
                           |        "abTests": "[{\"testName\":\"AmountHighlightTest\",\"testSlug\":\"highlight\",\"variantName\":\"Amount - 50 highlight\",\"variantSlug\":\"50\"},{\"testName\":\"MessageCopyTest\",\"testSlug\":\"mcopy\",\"variantName\":\"Copy - control\",\"variantSlug\":\"control\"},{\"testName\":\"PaymentMethodTest\",\"testSlug\":\"paymentMethods\",\"variantName\":\"Paypal\",\"variantSlug\":\"paypal\"}]",
                           |        "email": "a@a.a",
                           |        "idUser": "123",
-                          |        "contributionId": "7f5256d2-8e63-4b29-8f1e-f5c4e670db22"
+                          |        "contributionId": "7f5256d2-8e63-4b29-8f1e-f5c4e670db22",
+                          |        "countryCode": "uk"
                           |      },
                           |      "order": null,
                           |      "paid": true,


### PR DESCRIPTION
This adds a new layer to the `stripe.keys` config section that groups keys by Fastly country code and updates the `PaymentServices` logic accordingly. 

There's a new release of `membership-common` on the way which will require us to pass in a `Country` when creating `StripeApiConfig`, but that can be done in a separate PR when we update the dependency. 

Note that this will require a change to the configs in S3, which should be done immediately before deployment.