### PR TITLE
Contribution Ophan service update

### DIFF
--- a/app/models/StripeAcquisitionComponents.scala
+++ b/app/models/StripeAcquisitionComponents.scala
@@ -27,7 +27,7 @@ object StripeAcquisitionComponents {
           product = Product.Contribution,
           paymentFrequency = PaymentFrequency.OneOff,
           currency = charge.currency,
-          // Stripe amount in smallest currency unit.
+          // Stripe amount is in smallest currency unit.
           // Convert e.g. Pence to Pounds, Cents to Dollars
           // https://stripe.com/docs/api#charge_object
           amount = BigDecimal(charge.amount, 2).toDouble,

--- a/app/models/StripeAcquisitionComponents.scala
+++ b/app/models/StripeAcquisitionComponents.scala
@@ -27,7 +27,10 @@ object StripeAcquisitionComponents {
           product = Product.Contribution,
           paymentFrequency = PaymentFrequency.OneOff,
           currency = charge.currency,
-          amount = charge.amount,
+          // Stripe amount in smallest currency unit.
+          // Convert e.g. Pence to Pounds, Cents to Dollars
+          // https://stripe.com/docs/api#charge_object
+          amount = BigDecimal(charge.amount, 2).toDouble,
           amountInGBP = None, // Calculated at the sinks of the Ophan stream
           paymentProvider = Option(ophan.thrift.event.PaymentProvider.Stripe),
           campaignCode = Some(Set(request.body.intcmp, request.body.cmp).flatten),

--- a/app/utils/AttemptTo.scala
+++ b/app/utils/AttemptTo.scala
@@ -2,11 +2,10 @@ package utils
 
 import cats.syntax.EitherSyntax
 
-// TODO: have this extend classes where attemp to semnatics are used.
+// TODO: have this extend all classes where attempt to semantics are used.
 trait AttemptTo extends EitherSyntax {
 
   def attemptTo[A](description: String)(a: => A): Either[String, A] = {
     Either.catchNonFatal(a).leftMap(err => s"Unable to $description - underlying error: $err")
   }
 }
-

--- a/app/utils/AttemptTo.scala
+++ b/app/utils/AttemptTo.scala
@@ -1,0 +1,12 @@
+package utils
+
+import cats.syntax.EitherSyntax
+
+// TODO: have this extend classes where attemp to semnatics are used.
+trait AttemptTo extends EitherSyntax {
+
+  def attemptTo[A](description: String)(a: => A): Either[String, A] = {
+    Either.catchNonFatal(a).leftMap(err => s"Unable to $description - underlying error: $err")
+  }
+}
+

--- a/app/utils/QueryStringBindableUtils.scala
+++ b/app/utils/QueryStringBindableUtils.scala
@@ -8,7 +8,7 @@ import play.api.mvc.QueryStringBindable
 import scala.reflect.ClassTag
 import scala.util.Try
 
-object QueryStringBindableUtils {
+object QueryStringBindableUtils extends RuntimeClassUtils {
 
   /**
     * Utility function for building query string bindables.
@@ -44,11 +44,11 @@ object QueryStringBindableUtils {
     def decoder(data: String) = for {
 
       json <- Either.catchNonFatal(Json.parse(data)).leftMap { _ =>
-        s"""Unable to parse \"$data\" as JSON when attempting to decode an instance of ${reflect.classTag[A].runtimeClass}"""
+        s"""Unable to parse \"$data\" as JSON when attempting to decode an instance of ${runtimeClass[A]}"""
       }
 
       instance <- json.validate[A].asEither.leftMap { _ =>
-        s"Unable to decode JSON $json to an instance of ${reflect.classTag[A].runtimeClass}"
+        s"Unable to decode JSON $json to an instance of ${runtimeClass[A]}"
       }
 
     } yield instance

--- a/app/utils/RuntimeClassUtils.scala
+++ b/app/utils/RuntimeClassUtils.scala
@@ -1,0 +1,8 @@
+package utils
+
+import scala.reflect.ClassTag
+
+trait RuntimeClassUtils {
+
+  def runtimeClass[A : ClassTag]: Class[_] = reflect.classTag[A].runtimeClass
+}

--- a/app/utils/ThriftUtils.scala
+++ b/app/utils/ThriftUtils.scala
@@ -14,12 +14,10 @@ import scala.reflect.ClassTag
 
 case class ThriftDecodeError private (message: String)
 
-object ThriftDecodeError {
+object ThriftDecodeError extends RuntimeClassUtils {
 
-  def apply[A : ClassTag](value: String): ThriftDecodeError = {
-    val clazz = reflect.classTag[A].runtimeClass
-    new ThriftDecodeError(s"""unable to convert string "$value" to an instance of $clazz""")
-  }
+  def apply[A : ClassTag](value: String): ThriftDecodeError =
+    new ThriftDecodeError(s"""unable to convert string "$value" to an instance of ${runtimeClass[A]}""")
 }
 
 /**

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -71,7 +71,7 @@ trait AppComponents extends PlayComponents with GzipFilterComponents {
   lazy val identityService = new IdentityService(wsClient, idConfig)
   lazy val emailService = wire[EmailService]
 
-  lazy val ophanService = ContributionOphanService(environment)
+  lazy val ophanService = ContributionOphanService(config, environment)
   lazy val giraffeController = wire[Contributions]
   lazy val healthcheckController = wire[Healthcheck]
   lazy val assetController = wire[Assets]

--- a/app/wiring/PlayComponents.scala
+++ b/app/wiring/PlayComponents.scala
@@ -20,14 +20,6 @@ trait PlayComponents extends BuiltInComponents
   implicit val executionContext: ExecutionContext = actorSystem.dispatcher
   implicit val as: ActorSystem = actorSystem
 
-  // An actor materializer is initialized lazily in built-in components.
-  // However, it is up-cast to a Materializer,
-  // and the ContributionOphanService which is initialized in AppComponents requires specifically an ActorMaterializer.
-  // This is as a result of its dependency on com.gu.acquisition.services.OphanService
-  // Once OphanService has been updated to use an arbitrary materializer,
-  // this implicit val will no longer have to be initialised.
-  implicit val actorMaterializer: ActorMaterializer = ActorMaterializer()
-
   val jdbcExecutionContext: ExecutionContext = actorSystem.dispatchers.lookup("contexts.jdbc-context")
 
   val csrfAddToken = CSRFAddToken(csrfConfig, csrfTokenSigner)

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.11.95"
 val selenium = "org.seleniumhq.selenium" % "selenium-java" % "3.0.1" % Test
 val seleniumManager = "io.github.bonigarcia" % "webdrivermanager" % "1.7.1" % Test
 val seleniumHtmlUnitDriver = "org.seleniumhq.selenium" % "htmlunit-driver" % "2.23" % Test
-val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "0.2.1"
+val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "1.0.1"
 val simulacrum = "com.github.mpilquist" %% "simulacrum" % "0.10.0"
 
 // Used by simulacrum

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -80,3 +80,5 @@ contexts {
         }
     }
 }
+
+ophan.endpoint = "http://localhost:9000"


### PR DESCRIPTION
cc @guardian/contributions 

Changes:

- update the instance of the contribution Ophan service used by the application so that in development mode it can fire events to a test instance of the tracker e.g. one that is run locally
- correctly format the amount field for Stripe acquisition events
- (creates the `RuntimeClassUtils` trait to simplify providing the runtime class of types in log entries)

Have you gone through the contributions flow for all test variants ? __Yes, on CODE__