### PR TITLE
Ophan service instance with correct handling of test and default requests

### DIFF
--- a/app/services/ContributionOphanService.scala
+++ b/app/services/ContributionOphanService.scala
@@ -88,6 +88,11 @@ object ContributionOphanService extends LazyLogging {
 
   /**
     * Expects the config to have the path ophan.isProd defining a boolean.
+    * If this is true then acquisition events are sent to the production Ophan instance.
+    * Otherwise, a mock instance of the service is used -
+    * one that builds acquisition events, but doesn't send them -
+    * unless ophan.endpoint specifies a valid URI, in which case,
+    * acquisition events will be sent to this configurable endpoint.
     */
   def fromConfig(config: Config)(implicit system: ActorSystem, materializer: Materializer): ContributionOphanService = {
     val ophanConfig = config.getConfig("ophan")

--- a/app/utils/TestUserService.scala
+++ b/app/utils/TestUserService.scala
@@ -1,0 +1,25 @@
+package utils
+
+import com.gu.identity.play.AuthenticatedIdUser
+import com.gu.identity.testing.usernames.TestUsernames
+import play.api.mvc.RequestHeader
+
+trait TestUserService {
+
+  def isTestUser(request: RequestHeader): Boolean
+
+  def isTestUser(displayName: String): Boolean
+}
+
+class DefaultTestUserService(authProvider: AuthenticatedIdUser.Provider, testUsernames: TestUsernames)
+  extends TestUserService {
+
+  override def isTestUser(request: RequestHeader): Boolean =
+    request.getQueryString("_test_username")
+      .orElse(request.cookies.get("_test_username").map(_.value))
+      .orElse(authProvider(request).flatMap(_.displayName))
+      .exists(testUsernames.isValid)
+
+  override def isTestUser(displayName: String): Boolean =
+    displayName.split(' ').headOption.exists(testUsernames.isValid)
+}

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -21,6 +21,7 @@ import services._
 import router.Routes
 import configuration.{Config, CorsConfig, SupportConfig}
 import monitoring.{CloudWatch, CloudWatchMetrics}
+import utils.DefaultTestUserService
 
 //Sometimes intellij deletes this -> (import router.Routes)
 
@@ -56,10 +57,11 @@ trait AppComponents extends PlayComponents with GzipFilterComponents {
   lazy val cloudWatchClient = CloudWatch.build()
   lazy val cloudWatchMetrics = new CloudWatchMetrics(cloudWatchClient)
 
+  lazy val testUserService = new DefaultTestUserService(identityAuthProvider, testUsernames)
+
   lazy val paymentServices = new PaymentServices(
     config = config,
-    authProvider = identityAuthProvider,
-    testUsernames = testUsernames,
+    testUserService = testUserService,
     identityService = identityService,
     emailService = emailService,
     contributionDataPerMode = contributionDataPerMode,
@@ -71,7 +73,7 @@ trait AppComponents extends PlayComponents with GzipFilterComponents {
   lazy val identityService = new IdentityService(wsClient, idConfig)
   lazy val emailService = wire[EmailService]
 
-  lazy val ophanService = ContributionOphanService.fromConfig(config)
+  lazy val ophanService = ContributionOphanService(config, testUserService)
   lazy val giraffeController = wire[Contributions]
   lazy val healthcheckController = wire[Healthcheck]
   lazy val assetController = wire[Assets]

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -71,7 +71,7 @@ trait AppComponents extends PlayComponents with GzipFilterComponents {
   lazy val identityService = new IdentityService(wsClient, idConfig)
   lazy val emailService = wire[EmailService]
 
-  lazy val ophanService = ContributionOphanService(config, environment)
+  lazy val ophanService = ContributionOphanService.fromConfig(config)
   lazy val giraffeController = wire[Contributions]
   lazy val healthcheckController = wire[Healthcheck]
   lazy val assetController = wire[Assets]

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -82,5 +82,14 @@ contexts {
 }
 
 ophan {
-    isProd = false
+
+
+    default = TEST
+    testing = TEST
+
+    # Use to configure which endpoint the TEST Ophan service should submit acquisition events to.
+    # If testEndpoint is not specified then the TEST Ophan service will still attempt to build acquisition events,
+    # but will not submit them to an endpoint.
+
+    # testEndpoint = "http://localhost:9000"
 }

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -81,4 +81,6 @@ contexts {
     }
 }
 
-ophan.endpoint = "http://localhost:9000"
+ophan {
+    isProd = false
+}

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -78,3 +78,7 @@ contexts {
         }
     }
 }
+
+ophan {
+    isProd = true
+}

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -80,5 +80,6 @@ contexts {
 }
 
 ophan {
-    isProd = true
+    default = LIVE
+    testing = TEST
 }


### PR DESCRIPTION
cc @guardian/contributions 

The current Ophan instance used by the app is determined by inspecting the mode the Play app is running in - if in production mode, then the all acquisition events are sent to the production instance of Ophan, else an instance is created which fires events to a test endpoint (if specified in the config).

This implementation has some minor issues (which this pull request resolves):

- contributions frontend on CODE is running in production mode, meaning all acquisitions on CODE will be sent to Ophan
- test requests on the live version of the website will be sent to Ophan

In addition to this pull request, the `ophan.default` field in the private configuration for code will have to be overridden to `TEST`. This mirrors the pattern of how payment and database instances are determined for each request. 

Have you gone through the contributions flow for all test variants ? __Yes, locally__
