### PR TITLE
Stripe payments - include error message of generic error in log entry

### DIFF
--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -152,9 +152,9 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
         cloudWatchMetrics.logPaymentFailure(PaymentProvider.Stripe, request.platform)
         BadRequest(Json.toJson(e)).withHeaders(corsHeaders(request): _*)
       }
-      case _ => {
+      case err => {
         cloudWatchMetrics.logUnhandledPaymentFailure(PaymentProvider.Stripe, request.platform)
-        warn(s"Payment failed for unknown reason. contributions session id: ${request.sessionId}, from platform: ${request.platform}")
+        warn(s"Payment failed: ${err.getMessage}. contributions session id: ${request.sessionId}, from platform: ${request.platform}")
         BadRequest(Json.toJson("unknown error")).withHeaders(corsHeaders(request): _*)
       }
     }


### PR DESCRIPTION
@svillafe is trying to make a payment from S&C with a test user against the production instance of contributions frontend. We are currently unable to establish what the error is as the message returned is _for unknow reason_. This pull request includes the message of the exception in the log entry.

Have you gone through the contributions flow for all test variants ? __No__
