### PR TITLE
Move to acquisition event producer v2.0.0-rc.4

### DIFF
--- a/app/abtests/Test.scala
+++ b/app/abtests/Test.scala
@@ -1,16 +1,10 @@
 package abtests
 
-import actions.CommonActions.MetaDataRequest
 import com.github.slugify.Slugify
-import com.gu.acquisition.utils.AbTestConverter
-import play.api.db.Database
+import com.gu.acquisition.typeclasses.AbTestConverter
 import play.api.libs.json.{JsObject, JsValue, Json, Writes}
-import play.api.mvc.AnyContent
 import play.api.mvc.{Cookie, Request}
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.util.control.NonFatal
 import scala.util.matching.Regex
 
 case class Percentage(value: Double) {
@@ -23,7 +17,7 @@ case class Test(name: String, audienceSize: Percentage, audienceOffset: Percenta
   val idRange: Range = startId.to(endId).tail
 
   val slug: String = Test.slugify(name)
-  val cookieName: String = s"${Test.cookiePrefix}.${slug}"
+  val cookieName: String = s"${Test.cookiePrefix}.$slug"
 
   def allocate(id: Int, request: Request[_]): Option[Allocation] = {
     if (idRange.contains(id) && canRun(request)) Some(Allocation(this, variants.toList(id % variants.size)))

--- a/app/models/PaypalAcquisitionComponents.scala
+++ b/app/models/PaypalAcquisitionComponents.scala
@@ -2,11 +2,12 @@ package models
 
 import abtests.Allocation
 import actions.CommonActions.MetaDataRequest
+import com.gu.acquisition.model.OphanIds
 import com.paypal.api.payments.Payment
 import controllers.httpmodels.CaptureRequest
 import ophan.thrift.componentEvent.ComponentType
 import ophan.thrift.event._
-import services.ContributionOphanService.{ContributionAcquisitionSubmissionBuilder, OphanIds}
+import services.ContributionOphanService.ContributionAcquisitionSubmissionBuilder
 
 import scala.reflect.ClassTag
 
@@ -53,9 +54,8 @@ object PaypalAcquisitionComponents {
       def buildOphanIds(components: Execute): Either[String, OphanIds] = {
         import components._
         for {
-          browserId <- attemptToGet("browser id")(request.ophanBrowserId.get)
           pageviewId <- attemptToGet("pageview id")(request.ophanPageviewId.get)
-        } yield OphanIds(browserId, pageviewId, request.ophanVisitId)
+        } yield OphanIds(pageviewId, request.ophanVisitId, request.ophanBrowserId)
       }
 
       def buildAcquisition(components: Execute): Either[String, Acquisition] = {
@@ -92,9 +92,8 @@ object PaypalAcquisitionComponents {
       override def buildOphanIds(components: Capture): Either[String, OphanIds] = {
         import components._
         for {
-          browserId <- attemptToGet("browser id")(request.body.ophanBrowserId.get)
           pageviewId <- attemptToGet("pageview id")(request.body.ophanPageviewId.get)
-        } yield OphanIds(browserId, pageviewId, visitId = None)
+        } yield OphanIds(pageviewId, visitId = None, request.body.ophanBrowserId)
       }
 
       override def buildAcquisition(components: Capture): Either[String, Acquisition] = {

--- a/app/models/StripeAcquisitionComponents.scala
+++ b/app/models/StripeAcquisitionComponents.scala
@@ -1,10 +1,11 @@
 package models
 
 import actions.CommonActions.MetaDataRequest
+import com.gu.acquisition.model.OphanIds
 import com.gu.stripe.Stripe.Charge
 import controllers.forms.ContributionRequest
 import ophan.thrift.event.{Acquisition, PaymentFrequency, Product}
-import services.ContributionOphanService.{ContributionAcquisitionSubmissionBuilder, OphanIds}
+import services.ContributionOphanService.ContributionAcquisitionSubmissionBuilder
 
 case class StripeAcquisitionComponents(charge: Charge, request: MetaDataRequest[ContributionRequest])
 
@@ -15,9 +16,7 @@ object StripeAcquisitionComponents {
 
     def buildOphanIds(components: StripeAcquisitionComponents): Either[String, OphanIds] = {
       import components._
-      attemptToGet("ophan browser id")(request.body.ophanBrowserId.get).map { browserId =>
-        OphanIds(browserId, request.body.ophanPageviewId, request.body.ophanVisitId)
-      }
+      Right(OphanIds(request.body.ophanPageviewId, request.body.ophanVisitId, request.body.ophanBrowserId))
     }
 
     override def buildAcquisition(components: StripeAcquisitionComponents): Either[String, Acquisition] = {

--- a/app/services/ContributionOphanService.scala
+++ b/app/services/ContributionOphanService.scala
@@ -32,7 +32,7 @@ trait ContributionOphanService {
 
 /**
   * Wraps an Ophan service.
-  * Useful if you want to provide different logging dependent on whether the underlying service
+  * Useful if you want to provide different logging dependent on the underlying service
   * e.g. whether its attempting to send acquisition events to an Ophan endpoint, in addition to building them
   */
 class OphanServiceWithLogging(service: OphanService, infoMessage: LoggingContext => String)

--- a/app/services/ContributionOphanService.scala
+++ b/app/services/ContributionOphanService.scala
@@ -4,7 +4,7 @@ import abtests.Allocation
 import actions.CommonActions.MetaDataRequest
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.Materializer
 import cats.data.EitherT
 import com.gu.acquisition.model.AcquisitionSubmission
 import com.gu.acquisition.model.errors.OphanServiceError

--- a/app/services/ContributionOphanService.scala
+++ b/app/services/ContributionOphanService.scala
@@ -4,15 +4,17 @@ import abtests.Allocation
 import actions.CommonActions.MetaDataRequest
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
-import akka.stream.Materializer
+import akka.stream.{ActorMaterializer, Materializer}
 import cats.data.EitherT
-import com.gu.acquisition.services.OphanService
+import com.gu.acquisition.model.AcquisitionSubmission
+import com.gu.acquisition.model.errors.OphanServiceError
+import com.gu.acquisition.services.{MockOphanService, OphanService}
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import monitoring.{LoggingTags, TagAwareLogger}
-import ophan.thrift.event.{AbTest, AbTestInfo, Acquisition}
-import services.ContributionOphanService.{AcquisitionSubmission, AcquisitionSubmissionBuilder}
-import simulacrum.typeclass
+import ophan.thrift.event.{AbTest, AbTestInfo}
+import services.OphanServiceWithLogging.LoggingContext
 import utils.{AttemptTo, RuntimeClassUtils, TestUserService}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -25,74 +27,68 @@ trait ContributionOphanService {
     implicit ec: ExecutionContext,
     tags: LoggingTags,
     request: MetaDataRequest[_]
-  ): EitherT[Future, String, AcquisitionSubmission]
+  ): EitherT[Future, OphanServiceError, AcquisitionSubmission]
 }
 
-object MockOphanService extends ContributionOphanService with TagAwareLogger with RuntimeClassUtils {
+/**
+  * Wraps an Ophan service.
+  * Useful if you want to provide different logging dependent on whether the underlying service
+  * e.g. whether its attempting to send acquisition events to an Ophan endpoint, in addition to building them
+  */
+class OphanServiceWithLogging(service: OphanService, infoMessage: LoggingContext => String)
+  extends ContributionOphanService with TagAwareLogger with RuntimeClassUtils {
 
-  import AcquisitionSubmissionBuilder.ops._
   import cats.instances.future._
 
   def submitAcquisition[A : AcquisitionSubmissionBuilder : ClassTag](a: A)(
     implicit ec: ExecutionContext,
     tags: LoggingTags,
     request: MetaDataRequest[_]
-  ): EitherT[Future, String, AcquisitionSubmission] =
-    EitherT.fromEither[Future](a.asAcquisitionSubmission).bimap(
+  ): EitherT[Future, OphanServiceError, AcquisitionSubmission] =
+    service.submit(a).bimap(
       err => {
-        error(err)
+        error(s"${err.getMessage} - contributions session id ${request.sessionId}")
         err
       },
       submission => {
-        info(s"Acquisition submission created from instance of ${runtimeClass[A]} - $submission")
+        val context = LoggingContext(runtimeClass[A], request, submission)
+        info(infoMessage(context))
         submission
       }
     )
 }
 
-class DefaultContributionOphanService(service: OphanService)
-  extends ContributionOphanService with TagAwareLogger with RuntimeClassUtils {
+object OphanServiceWithLogging {
 
-  import cats.instances.future._
-  import actions.CommonActions._
-  import AcquisitionSubmissionBuilder.ops._
+  /**
+    * Context required to for useful logging messages on a successful acquisition submission.
+    */
+  private[services] case class LoggingContext(
+    runtimeClass: Class[_],
+    request: MetaDataRequest[_],
+    submission: AcquisitionSubmission
+  )
 
-  private def sendSubmission(submission: AcquisitionSubmission)(implicit executionContext: ExecutionContext) = {
-    import submission._
-    service.submit(acquisition, ophanIds.browserId, ophanIds.viewId, ophanIds.visitId)
-      .bimap(err => s"Failed to submit acquisition event to Ophan - ${err.getMessage}", _ => submission)
-  }
+  def io(uri: Uri)(implicit system: ActorSystem, mat: Materializer): OphanServiceWithLogging =
+    new OphanServiceWithLogging(OphanService(uri), { ctx =>
+      s"Acquisition submission created from an instance of ${ctx.runtimeClass} and " +
+      s"successfully submitted to Ophan - contributions session id ${ctx.request.sessionId}"
+    })
 
-  def submitAcquisition[A : AcquisitionSubmissionBuilder : ClassTag](a: A)(
-    implicit ec: ExecutionContext,
-    tags: LoggingTags,
-    request: MetaDataRequest[_]
-  ): EitherT[Future, String, AcquisitionSubmission] =
-    EitherT.fromEither[Future](a.asAcquisitionSubmission).flatMap(sendSubmission)
-      .bimap(
-        err => {
-          error(s"$err - contributions session id ${request.sessionId}")
-          err
-        },
-        submission => {
-          info(
-            s"Acquisition submission created from an instance of ${runtimeClass[A]} and " +
-            s"successfully submitted to Ophan - contributions session id ${request.sessionId}"
-          )
-          submission
-        }
-      )
+  def mock: OphanServiceWithLogging = new OphanServiceWithLogging(MockOphanService, { ctx =>
+    s"Acquisition submission created from an instance of ${ctx.runtimeClass} - submission: ${ctx.submission}"
+  })
 }
 
 class RequestDependentOphanService(
-    default: ContributionOphanService,
-    testing: ContributionOphanService,
-    testUserService: TestUserService
-) extends ContributionOphanService {
+  default: OphanServiceWithLogging,
+  testing: OphanServiceWithLogging,
+  testUserService: TestUserService
+) extends ContributionOphanService with TagAwareLogger with RuntimeClassUtils {
 
   override def submitAcquisition[A: AcquisitionSubmissionBuilder : ClassTag](a: A)(
     implicit ec: ExecutionContext, tags: LoggingTags, request: MetaDataRequest[_]
-  ): EitherT[Future, String, AcquisitionSubmission] =
+  ): EitherT[Future, OphanServiceError, AcquisitionSubmission] =
     if (testUserService.isTestUser(request)) testing.submitAcquisition(a) else default.submitAcquisition(a)
 }
 
@@ -106,23 +102,23 @@ object ContributionOphanService extends LazyLogging {
 
     lazy val productionService = {
       logger.info("Initialising production Ophan service")
-      new DefaultContributionOphanService(OphanService.prod)
+      OphanServiceWithLogging.io(OphanService.prodEndpoint)
     }
 
-    lazy val testService: ContributionOphanService = {
+    lazy val testService = {
       logger.info("Initializing test Ophan service...")
       val endpoint = Try(ophanConfig.getString("testEndpoint")).toOption
       if (endpoint.isEmpty) {
         logger.info("No endpoint specified for test Ophan service. Using mock Ophan service.")
-        MockOphanService
+        OphanServiceWithLogging.mock
       } else {
         val uri = Try(Uri.parseAbsolute(endpoint.get)).toOption
         if (uri.isEmpty) {
           logger.error("Invalid endpoint specified for test Ophan service. Using mock Ophan service.")
-          MockOphanService
+          OphanServiceWithLogging.mock
         } else {
           logger.info(s"Using ${uri.get} as the endpoint for the test Ophan service.")
-          new DefaultContributionOphanService(new OphanService(uri.get))
+          OphanServiceWithLogging.io(uri.get)
         }
       }
     }
@@ -148,31 +144,6 @@ object ContributionOphanService extends LazyLogging {
     new RequestDependentOphanService(default, testing, testUserService)
   }
 
-  case class OphanIds(browserId: String, viewId: String, visitId: Option[String])
-
-  /**
-    * Encapsulates all the data required to submit an acquisition to Ophan.
-    */
-  case class AcquisitionSubmission(ophanIds: OphanIds, acquisition: Acquisition)
-
-  /**
-    * Type class for creating an acquisition submission from an arbitrary data type.
-    */
-  @typeclass trait AcquisitionSubmissionBuilder[A] {
-    import cats.syntax.either._
-
-    def buildOphanIds(a: A): Either[String, OphanIds]
-
-    def buildAcquisition(a: A): Either[String, Acquisition]
-
-    def asAcquisitionSubmission(a: A): Either[String, AcquisitionSubmission] =
-      for {
-        ophanIds <- buildOphanIds(a)
-        acquisition <- buildAcquisition(a)
-      } yield AcquisitionSubmission(ophanIds, acquisition)
-  }
-
-
   trait ContributionAcquisitionSubmissionBuilder[A] extends AcquisitionSubmissionBuilder[A]
     with AttemptTo with RuntimeClassUtils {
 
@@ -185,7 +156,7 @@ object ContributionOphanService extends LazyLogging {
       * Combine the tests the user is in on the contributions website and the referring page.
       */
     protected def abTestInfo(contributionAbTests: Set[Allocation], referrerAbTest: Option[AbTest]): AbTestInfo = {
-      import com.gu.acquisition.syntax._
+      import com.gu.acquisition.syntax.iterable._
       val abTestInfo = contributionAbTests.asAbTestInfo
       referrerAbTest.map(abTest => AbTestInfo(abTestInfo.tests + abTest)).getOrElse(abTestInfo)
     }

--- a/app/services/ContributionOphanService.scala
+++ b/app/services/ContributionOphanService.scala
@@ -67,7 +67,7 @@ object OphanServiceWithLogging {
     submission: AcquisitionSubmission
   )
 
-  def io(uri: HttpUrl)(implicit client: OkHttpClient): OphanServiceWithLogging =
+  def http(uri: HttpUrl)(implicit client: OkHttpClient): OphanServiceWithLogging =
     new OphanServiceWithLogging(OphanService(uri), { ctx =>
       s"Acquisition submission created from an instance of ${ctx.runtimeClass} and " +
       s"successfully submitted to Ophan - contributions session id ${ctx.request.sessionId}"
@@ -100,7 +100,7 @@ object ContributionOphanService extends LazyLogging {
 
     lazy val productionService = {
       logger.info("Initialising production Ophan service")
-      OphanServiceWithLogging.io(OphanService.prodEndpoint)
+      OphanServiceWithLogging.http(OphanService.prodEndpoint)
     }
 
     lazy val testService = {
@@ -116,7 +116,7 @@ object ContributionOphanService extends LazyLogging {
           OphanServiceWithLogging.mock
         } else {
           logger.info(s"Using ${uri.get} as the endpoint for the test Ophan service.")
-          OphanServiceWithLogging.io(uri.get)
+          OphanServiceWithLogging.http(uri.get)
         }
       }
     }

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -1,12 +1,10 @@
 package wiring
 
-import akka.stream.Materializer
 import com.github.nscala_time.time.Imports._
 import com.gu.identity.cookie.{PreProductionKeys, ProductionKeys}
 import com.gu.identity.play.AccessCredentials.{Cookies, Token}
 import com.gu.identity.testing.usernames.TestUsernames
 import com.gu.monitoring.ServiceMetrics
-import com.gu.okhttp.RequestRunners
 import com.softwaremill.macwire._
 import com.typesafe.config.ConfigFactory
 import controllers._
@@ -77,6 +75,7 @@ trait AppComponents extends PlayComponents with GzipFilterComponents {
   lazy val emailService = wire[EmailService]
 
   lazy val ophanService = ContributionOphanService(config, testUserService)
+
   lazy val giraffeController = wire[Contributions]
   lazy val healthcheckController = wire[Healthcheck]
   lazy val assetController = wire[Assets]

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.11.95"
 val selenium = "org.seleniumhq.selenium" % "selenium-java" % "3.0.1" % Test
 val seleniumManager = "io.github.bonigarcia" % "webdrivermanager" % "1.7.1" % Test
 val seleniumHtmlUnitDriver = "org.seleniumhq.selenium" % "htmlunit-driver" % "2.23" % Test
-val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "1.0.1"
+val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "2.0.0-rc.3"
 val simulacrum = "com.github.mpilquist" %% "simulacrum" % "0.10.0"
 
 // Used by simulacrum

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.11.95"
 val selenium = "org.seleniumhq.selenium" % "selenium-java" % "3.0.1" % Test
 val seleniumManager = "io.github.bonigarcia" % "webdrivermanager" % "1.7.1" % Test
 val seleniumHtmlUnitDriver = "org.seleniumhq.selenium" % "htmlunit-driver" % "2.23" % Test
-val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "2.0.0-rc.3"
+val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "2.0.0-rc.4"
 val simulacrum = "com.github.mpilquist" %% "simulacrum" % "0.10.0"
 
 // Used by simulacrum

--- a/test/abtests/AllocationSpec.scala
+++ b/test/abtests/AllocationSpec.scala
@@ -17,7 +17,7 @@ class AllocationSpec extends PlaySpec {
       Mockito.when(mockAllocation.test.slug).thenReturn(testName)
       Mockito.when(mockAllocation.variant.name).thenReturn(variantName)
 
-      import com.gu.acquisition.utils.AbTestConverter.ops._
+      import com.gu.acquisition.typeclasses.AbTestConverter.ops._
 
       val test = mockAllocation.asAbTest
 

--- a/test/controllers/PaypalControllerSpec.scala
+++ b/test/controllers/PaypalControllerSpec.scala
@@ -20,10 +20,10 @@ import play.api.test.Helpers._
 import play.filters.csrf.CSRFCheck
 import services.{ContributionOphanService, PaymentServices, PaypalService}
 import cats.instances.future._
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
 import org.mockito.internal.verification.VerificationModeFactory
 import org.scalatest.concurrent.ScalaFutures
 import play.api.libs.json.Json
-import services.ContributionOphanService.AcquisitionSubmissionBuilder
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}


### PR DESCRIPTION
cc @guardian/contributions 

`v2.0.0-rc.3` uses `fezziwig` to serialise Thrift data types. Therefore, to avoid loss of acquisition events, [#2448](https://github.com/guardian/ophan/pull/2448) in the `ophan` repository should be merged first. Then, once this pull request has been merged and deployed, we should be able to remove the old extraction logic for acquisition events in `the-slab`.

Have you gone through the contributions flow for all test variants ? __Yes, tested on CODE__
