### PR TITLE
acquisition event producer version bump

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.11.95"
 val selenium = "org.seleniumhq.selenium" % "selenium-java" % "3.0.1" % Test
 val seleniumManager = "io.github.bonigarcia" % "webdrivermanager" % "1.7.1" % Test
 val seleniumHtmlUnitDriver = "org.seleniumhq.selenium" % "htmlunit-driver" % "2.23" % Test
-val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "2.0.0-rc.4"
+val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "2.0.0-rc.5"
 val simulacrum = "com.github.mpilquist" %% "simulacrum" % "0.10.0"
 
 // Used by simulacrum


### PR DESCRIPTION
__DO NOT MERGE YET - AWAITING RELASE OF 2.0.0-rc.5__

cc @guardian/contributions 

Bumps the acquisition event producer version. See [#15](https://github.com/guardian/acquisition-event-producer/pull/15) for why version `2.0.0-rc.4` was no good!

Have you gone through the contributions flow for all test variants ? __Yes, locally__
