### PR TITLE
Improved Paypal logging

### DIFF
--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -148,7 +148,8 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
 
       render {
         case Accepts.Json() => BadRequest(JsNull)
-        case Accepts.Html() => Redirect(routes.Contributions.contribute(countryGroup, Some(PaypalError)).url, SEE_OTHER)
+        case Accepts.Html() =>
+          Redirect(routes.Contributions.contribute(countryGroup, Some(PaypalError)).url, SEE_OTHER)
       }
     }
 

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -134,12 +134,21 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
       )
 
     def notOkResult(paypalError: PaypalApiError): Result = {
-      error(s"Error executing PayPal payment for contributions session id: ${request.sessionId} \n\t error message: ${paypalError.message}")
+
+      val message = s"Error executing PayPal payment for contributions session id: ${request.sessionId} " +
+        s"error message: ${paypalError.message}"
+
+      paypalError.errorType match {
+        // This signifies an issue with the user's account. Don't pollute error level logs with such issues.
+        case PaypalErrorType.InstrumentDeclined => warn(message)
+        case _ => error(message)
+      }
+
       cloudWatchMetrics.logPaymentFailure(PaymentProvider.Paypal, request.platform)
+
       render {
         case Accepts.Json() => BadRequest(JsNull)
-        case Accepts.Html() =>
-          Redirect(routes.Contributions.contribute(countryGroup, Some(PaypalError)).url, SEE_OTHER)
+        case Accepts.Html() => Redirect(routes.Contributions.contribute(countryGroup, Some(PaypalError)).url, SEE_OTHER)
       }
     }
 

--- a/app/models/PaypalApiError.scala
+++ b/app/models/PaypalApiError.scala
@@ -40,7 +40,7 @@ object PaypalApiError {
       val errorMessage = (for {
         error <- Option(paypalException.getDetails)
         message <- Option(error.getMessage)
-        message if message != ""
+        if message != ""
       } yield message).getOrElse("Unknown error message")
 
       PaypalApiError(PaypalErrorType.fromPaypalError(paypalException.getDetails), errorMessage)

--- a/app/models/PaypalApiError.scala
+++ b/app/models/PaypalApiError.scala
@@ -13,11 +13,13 @@ object PaypalErrorType extends Enum[PaypalErrorType] with PlayJsonEnum[PaypalErr
 
   case object NotFound extends PaypalErrorType
   case object PaymentAlreadyDone extends PaypalErrorType
+  case object InstrumentDeclined extends PaypalErrorType
   case object Other extends PaypalErrorType
 
   def fromPaypalError(error: Error): PaypalErrorType = error.getName match {
     case "INVALID_RESOURCE_ID" => NotFound
     case "PAYMENT_ALREADY_DONE" => PaymentAlreadyDone
+    case "INSTRUMENT_DECLINED" => InstrumentDeclined
     case _ => Other
   }
 }
@@ -28,22 +30,21 @@ case class PaypalApiError(
 )
 
 object PaypalApiError {
+
   def fromString(message: String): PaypalApiError = PaypalApiError(PaypalErrorType.Other, message)
 
-  private def detailToString(details: ErrorDetails): String =
-    s"""
-       |field: ${details.getField}
-       |issue: ${details.getIssue}
-       |""".stripMargin
-
   def fromThrowable(exception: Throwable): PaypalApiError = exception match {
+
     case paypalException: PayPalRESTException =>
-      val details = Option(paypalException.getDetails)
-        .flatMap(d => Option(d.getDetails))
-        .map(_.asScala).getOrElse(Nil)
-        .map(detailToString)
-        .mkString(";\n")
-      PaypalApiError(PaypalErrorType.fromPaypalError(paypalException.getDetails), details)
+
+      val errorMessage = (for {
+        error <- Option(paypalException.getDetails)
+        message <- Option(error.getMessage)
+        message if message != ""
+      } yield message).getOrElse("Unknown error message")
+
+      PaypalApiError(PaypalErrorType.fromPaypalError(paypalException.getDetails), errorMessage)
+
     case exception: Exception =>
       PaypalApiError.fromString(exception.getMessage)
   }

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -57,13 +57,8 @@ class PaypalService(
 
   def apiContext: APIContext = new APIContext(credentials.clientId, credentials.clientSecret, config.paypalMode)
 
-  private def asyncExecute[A](block: => A)(implicit tags: LoggingTags): EitherT[Future, PaypalApiError, A] = {
-    Future(block).attemptT.leftMap {
-      case NonFatal(throwable) =>
-        error("Error while calling Paypal API", throwable)
-        PaypalApiError.fromThrowable(throwable)
-    }
-  }
+  private def asyncExecute[A](block: => A)(implicit tags: LoggingTags): EitherT[Future, PaypalApiError, A] =
+    Future(block).attemptT.leftMap { case NonFatal(throwable) => PaypalApiError.fromThrowable(throwable) }
 
   private def fullName(payerInfo: PayerInfo): Option[String] = {
     val firstName = Option(payerInfo.getFirstName)


### PR DESCRIPTION
Current issues with Paypal logging:

- logs are 'polluted' with a lot of `INSTRUMENT_DECLINED` errors
- some error messages are duplicated
- some error messages are empty

This pull request aims to fix these issues.

Have you gone through the contributions flow for all test variants ? __Yes, tested locally__
