### PR TITLE
/stripe/pay endpoint update

### DIFF
--- a/app/controllers/forms/ContributionRequest.scala
+++ b/app/controllers/forms/ContributionRequest.scala
@@ -28,7 +28,9 @@ case class ContributionRequest(
   componentId: Option[String],
   componentType: Option[ComponentType],
   source: Option[AcquisitionSource],
-  abTest: Option[AbTest]
+  abTest: Option[AbTest], // Deprecated
+  refererAbTest: Option[AbTest],
+  nativeAbTests: Option[Set[AbTest]]
 )
 
 object ContributionRequest {

--- a/app/models/StripeAcquisitionComponents.scala
+++ b/app/models/StripeAcquisitionComponents.scala
@@ -33,7 +33,7 @@ object StripeAcquisitionComponents {
           amountInGBP = None, // Calculated at the sinks of the Ophan stream
           paymentProvider = Option(ophan.thrift.event.PaymentProvider.Stripe),
           campaignCode = Some(Set(request.body.intcmp, request.body.cmp).flatten),
-          abTests = Some(abTestInfo(request.body.nativeAbTests, request.body.abTest)),
+          abTests = Some(abTestInfo(request.body.nativeAbTests, request.body.refererAbTest)),
           countryCode = Some(charge.source.country),
           referrerPageViewId = request.body.refererPageviewId,
           referrerUrl = request.body.refererUrl,

--- a/app/models/StripeAcquisitionComponents.scala
+++ b/app/models/StripeAcquisitionComponents.scala
@@ -33,7 +33,7 @@ object StripeAcquisitionComponents {
           amountInGBP = None, // Calculated at the sinks of the Ophan stream
           paymentProvider = Option(ophan.thrift.event.PaymentProvider.Stripe),
           campaignCode = Some(Set(request.body.intcmp, request.body.cmp).flatten),
-          abTests = Some(abTestInfo(request.testAllocations, request.body.abTest)),
+          abTests = Some(abTestInfo(request.body.nativeAbTests, request.body.abTest)),
           countryCode = Some(charge.source.country),
           referrerPageViewId = request.body.refererPageviewId,
           referrerUrl = request.body.refererUrl,

--- a/app/services/ContributionOphanService.scala
+++ b/app/services/ContributionOphanService.scala
@@ -144,6 +144,7 @@ object ContributionOphanService extends LazyLogging {
 
   trait ContributionAcquisitionSubmissionBuilder[A] extends AcquisitionSubmissionBuilder[A]
     with AttemptTo with RuntimeClassUtils {
+    import scala.collection.Set
 
     protected def attemptToGet[B](field: String)(a: => B)(implicit classTag: ClassTag[A]): Either[String, B] =
       attemptTo[B](s"get $field")(a).leftMap { err =>
@@ -155,8 +156,16 @@ object ContributionOphanService extends LazyLogging {
       */
     protected def abTestInfo(contributionAbTests: Set[Allocation], referrerAbTest: Option[AbTest]): AbTestInfo = {
       import com.gu.acquisition.syntax.iterable._
-      val abTestInfo = contributionAbTests.asAbTestInfo
-      referrerAbTest.map(abTest => AbTestInfo(abTestInfo.tests + abTest)).getOrElse(abTestInfo)
+      abTestInfo(Some(contributionAbTests.asAbTestInfo.tests), referrerAbTest)
+    }
+
+    /**
+      * Combine the tests the user is in on the native and referring websites.
+      */
+    protected def abTestInfo(nativeAbTests: Option[Set[AbTest]], referrerAbTest: Option[AbTest]): AbTestInfo = {
+      var abTests = nativeAbTests.getOrElse(Set.empty)
+      referrerAbTest.foreach(abTests += _)
+      AbTestInfo(abTests)
     }
   }
 }

--- a/assets/javascripts/src/actions.es6
+++ b/assets/javascripts/src/actions.es6
@@ -141,7 +141,6 @@ function paymentFormData(state, token) {
         token: token,
         marketing: state.details.optIn,
         postcode: state.details.postcode,
-        abTests: state.data.abTests,
         ophanPageviewId: state.data.ophan.pageviewId,
         ophanBrowserId: state.data.ophan.browserId,
         cmp: state.data.cmpCode,
@@ -152,6 +151,7 @@ function paymentFormData(state, token) {
         componentId: state.data.componentId,
         componentType: state.data.componentType,
         source: state.data.source,
-        abTest: state.data.referrerAbTest
+        refererAbTest: state.data.refererAbTest,
+        nativeAbTests: state.data.abTests
     };
 }

--- a/assets/javascripts/src/actions.es6
+++ b/assets/javascripts/src/actions.es6
@@ -160,7 +160,7 @@ function paymentFormData(state, token) {
         componentId: state.data.componentId,
         componentType: state.data.componentType,
         source: state.data.source,
-        refererAbTest: state.data.refererAbTest,
+        refererAbTest: state.data.referrerAbTest,
         nativeAbTests: useOphanEncodingForAbTests(state.data.abTests)
     };
 }

--- a/assets/javascripts/src/actions.es6
+++ b/assets/javascripts/src/actions.es6
@@ -126,13 +126,22 @@ export function trackCheckoutStep(checkoutStep, actionName, label) {
     }
 }
 
+
 /**
- * Convert app state to the structure required for payment posts
- *
- * @param state
- * @return object
+ * Convert app state to the structure required for posts to the /stripe/pay endpoint
  */
 function paymentFormData(state, token) {
+
+    // /stripe/pay endpoint requires AB tests to be serialized using the Ophan encoding.
+    function useOphanEncodingForAbTests(abTests) {
+        return abTests.map(abTest => {
+            return {
+                name: abTest.testSlug,
+                variant: abTest.variantSlug
+            }
+        })
+    }
+
     return {
         name: state.details.name,
         currency: state.data.currency.code,
@@ -152,6 +161,6 @@ function paymentFormData(state, token) {
         componentType: state.data.componentType,
         source: state.data.source,
         refererAbTest: state.data.refererAbTest,
-        nativeAbTests: state.data.abTests
+        nativeAbTests: useOphanEncodingForAbTests(state.data.abTests)
     };
 }

--- a/test/forms/ContributionRequestSpec.scala
+++ b/test/forms/ContributionRequestSpec.scala
@@ -29,7 +29,9 @@ class ContributionRequestSpec extends PlaySpec with EitherValues {
     componentId = None,
     componentType = None,
     source = None,
-    abTest = None
+    abTest = None,
+    refererAbTest = None,
+    nativeAbTests = None
   )
 
   val baseJson: JsObject =  Json.obj(
@@ -80,6 +82,18 @@ class ContributionRequestSpec extends PlaySpec with EitherValues {
       val json = baseJson ++ Json.obj("abTest" -> Json.obj("name" -> "name", "variant" -> "variant"))
 
       checkJson(request, json)
+
+      val request2 = baseRequest.copy(refererAbTest = Some(ophan.thrift.event.AbTest("name", "variant")))
+
+      val json2 = baseJson ++ Json.obj("refererAbTest" -> Json.obj("name" -> "name", "variant" -> "variant"))
+
+      checkJson(request2, json2)
+
+      val request3 = baseRequest.copy(nativeAbTests = Some(Set(ophan.thrift.event.AbTest("name", "variant"))))
+
+      val json3 = baseJson ++ Json.obj("nativeAbTests" -> Json.arr(Json.obj("name" -> "name", "variant" -> "variant")))
+
+      checkJson(request3, json3)
     }
   }
 }


### PR DESCRIPTION
Previously, the field `abTest` in the body of the request to `/stripe/pay` was used to record the AB test the user was in on the referring page; the tests they were in on the contributions website was inferred from a cookie. However, when `/stripe/pay` is called from support frontend, the AB tests the user was in on the Supporter website can not be included in the request.

This pull request updates the `/stripe/pay` endpoint so that the fields `refererAbTest` and `nativeAbTests` can be included in the body of the request, and sets a precedent that they should be used to record the (optional) AB test the user was in on the referring page, and the AB tests they were in on the native website respectively.

See [#270](https://github.com/guardian/support-frontend/pull/270) on support-frontend which uses this updated endpoint.

Here is an example of the data that is getting posted to the `/stripe/pay` endpoint from the contributions website:

<img width="565" alt="stripe_pay_request_body" src="https://user-images.githubusercontent.com/4085817/31436985-a5e98ba4-ae7b-11e7-98c9-3a33dc9a302f.png">


Have you gone through the contributions flow for all test variants ? __Yes, locally, on code and from Support frontend on code__
