### PR TITLE
Add S3 bucket parameter to riff-raff.yml

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -26,4 +26,6 @@ deployments:
 
   contributions-frontend:
     type: autoscaling
+    parameters:
+        bucket: membership-dist
     dependencies: [cfn, contributions-frontend-ami, contributions-frontend-static]


### PR DESCRIPTION
Fixes a warning in Riff Raff where this parameter isn't specified.

@guardian/contributions 
