### PR TITLE
Acquisition event producer version bump

### DIFF
--- a/app/models/PaypalAcquisitionComponents.scala
+++ b/app/models/PaypalAcquisitionComponents.scala
@@ -53,9 +53,7 @@ object PaypalAcquisitionComponents {
 
       def buildOphanIds(components: Execute): Either[String, OphanIds] = {
         import components._
-        for {
-          pageviewId <- attemptToGet("pageview id")(request.ophanPageviewId.get)
-        } yield OphanIds(pageviewId, request.ophanVisitId, request.ophanBrowserId)
+        Right(OphanIds(request.ophanPageviewId, request.ophanVisitId, request.ophanBrowserId))
       }
 
       def buildAcquisition(components: Execute): Either[String, Acquisition] = {
@@ -90,10 +88,8 @@ object PaypalAcquisitionComponents {
     implicit object paypalAcquisitionSubmissionBuilder extends PaypalAcquisitionSubmissionBuilder[Capture] {
 
       override def buildOphanIds(components: Capture): Either[String, OphanIds] = {
-        import components._
-        for {
-          pageviewId <- attemptToGet("pageview id")(request.body.ophanPageviewId.get)
-        } yield OphanIds(pageviewId, visitId = None, request.body.ophanBrowserId)
+        import components.request.body
+        Right(OphanIds(body.ophanPageviewId, visitId = None, body.ophanBrowserId))
       }
 
       override def buildAcquisition(components: Capture): Either[String, Acquisition] = {

--- a/app/models/StripeAcquisitionComponents.scala
+++ b/app/models/StripeAcquisitionComponents.scala
@@ -16,12 +16,12 @@ object StripeAcquisitionComponents {
 
     def buildOphanIds(components: StripeAcquisitionComponents): Either[String, OphanIds] = {
       import components._
-      Right(OphanIds(request.body.ophanPageviewId, request.body.ophanVisitId, request.body.ophanBrowserId))
+      Right(OphanIds(Some(request.body.ophanPageviewId), request.body.ophanVisitId, request.body.ophanBrowserId))
     }
 
     override def buildAcquisition(components: StripeAcquisitionComponents): Either[String, Acquisition] = {
       import components._
-      Either.right(
+      Right(
         Acquisition(
           product = Product.Contribution,
           paymentFrequency = PaymentFrequency.OneOff,

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.11.95"
 val selenium = "org.seleniumhq.selenium" % "selenium-java" % "3.0.1" % Test
 val seleniumManager = "io.github.bonigarcia" % "webdrivermanager" % "1.7.1" % Test
 val seleniumHtmlUnitDriver = "org.seleniumhq.selenium" % "htmlunit-driver" % "2.23" % Test
-val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "2.0.0-rc.5"
+val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "2.0.0"
 val simulacrum = "com.github.mpilquist" %% "simulacrum" % "0.10.0"
 
 // Used by simulacrum


### PR DESCRIPTION
Updates contributions to use `"com.gu" %% "acquisition-event-producer" % "2.0.0"`. This enables acquisitions events to still be submitted, even when the client doesn't submit a page view id.


Have you gone through the contributions flow for all test variants ? __Yes, locally__
