### PR TITLE
acquisition event producer v2.0.1

### DIFF
--- a/app/models/PaypalAcquisitionComponents.scala
+++ b/app/models/PaypalAcquisitionComponents.scala
@@ -1,6 +1,5 @@
 package models
 
-import abtests.Allocation
 import actions.CommonActions.MetaDataRequest
 import com.gu.acquisition.model.OphanIds
 import com.paypal.api.payments.Payment
@@ -65,7 +64,6 @@ object PaypalAcquisitionComponents {
             paymentFrequency = PaymentFrequency.OneOff,
             currency = info.currency,
             amount = info.amount,
-            amountInGBP = None, // Calculated at the sinks of the Ophan stream
             paymentProvider = Some(ophan.thrift.event.PaymentProvider.Paypal),
             campaignCode = Some(Set(request.intCmp, request.cmp).flatten),
             abTests = Some(abTestInfo(request.nativeAbTests, request.refererAbTest)),
@@ -74,7 +72,8 @@ object PaypalAcquisitionComponents {
             referrerUrl = request.refererUrl,
             componentId = request.componentId,
             componentTypeV2 = request.componentType,
-            source = request.source
+            source = request.source,
+            platform = Some(ophan.thrift.event.Platform.Contribution)
           )
         }
       }
@@ -101,7 +100,6 @@ object PaypalAcquisitionComponents {
             paymentFrequency = ophan.thrift.event.PaymentFrequency.OneOff,
             currency = info.currency,
             amount = info.amount,
-            amountInGBP = None, // Calculated at the sinks of the Ophan stream
             paymentProvider = Some(ophan.thrift.event.PaymentProvider.Paypal),
             campaignCode = Some(Set(request.body.cmp, request.body.intCmp).flatten),
             abTests = Some(abTestInfo(request.body.nativeAbTests, request.body.refererAbTest)),
@@ -110,7 +108,8 @@ object PaypalAcquisitionComponents {
             referrerUrl = request.body.refererUrl,
             componentId = request.body.componentId,
             componentTypeV2 = request.body.componentType,
-            source = request.body.source
+            source = request.body.source,
+            platform = Some(ophan.thrift.event.Platform.Contribution)
           )
         }
       }

--- a/app/models/StripeAcquisitionComponents.scala
+++ b/app/models/StripeAcquisitionComponents.scala
@@ -30,7 +30,6 @@ object StripeAcquisitionComponents {
           // Convert e.g. Pence to Pounds, Cents to Dollars
           // https://stripe.com/docs/api#charge_object
           amount = BigDecimal(charge.amount, 2).toDouble,
-          amountInGBP = None, // Calculated at the sinks of the Ophan stream
           paymentProvider = Option(ophan.thrift.event.PaymentProvider.Stripe),
           campaignCode = Some(Set(request.body.intcmp, request.body.cmp).flatten),
           abTests = Some(abTestInfo(request.body.nativeAbTests, request.body.refererAbTest)),
@@ -39,7 +38,8 @@ object StripeAcquisitionComponents {
           referrerUrl = request.body.refererUrl,
           componentId = request.body.componentId,
           componentTypeV2 = request.body.componentType,
-          source = request.body.source
+          source = request.body.source,
+          platform = Some(ophan.thrift.event.Platform.Contribution)
         )
       )
     }

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.11.95"
 val selenium = "org.seleniumhq.selenium" % "selenium-java" % "3.0.1" % Test
 val seleniumManager = "io.github.bonigarcia" % "webdrivermanager" % "1.7.1" % Test
 val seleniumHtmlUnitDriver = "org.seleniumhq.selenium" % "htmlunit-driver" % "2.23" % Test
-val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "2.0.0"
+val acquisitionEventProducer = "com.gu" %% "acquisition-event-producer" % "2.0.1"
 val simulacrum = "com.github.mpilquist" %% "simulacrum" % "0.10.0"
 
 // Used by simulacrum


### PR DESCRIPTION
Use latest version of acquisition event producer so platform can be included in acquisition events. This is useful as platform can not be reliably inferred in the data lake job. Also, the amount in GBP field is deprecated as it's calculated at the sinks of the Ophan stream.

Have you gone through the contributions flow for all test variants ? __Yes, tested on CODE__
