### PR TITLE
Support platform accounted for when sending acquisition events

### DIFF
--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -189,7 +189,8 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
         componentType = componentType,
         source = source,
         refererAbTest = refererAbTest,
-        nativeAbTests = nativeAbTests
+        nativeAbTests = nativeAbTests,
+        isSupport = supportRedirect
       )
 
     paypalService.executePayment(paymentId, payerId)

--- a/app/controllers/forms/ContributionRequest.scala
+++ b/app/controllers/forms/ContributionRequest.scala
@@ -3,7 +3,7 @@ package controllers.forms
 import com.gu.i18n.Currency
 import models.IdentityId
 import ophan.thrift.componentEvent.ComponentType
-import ophan.thrift.event.{AbTest, AcquisitionSource}
+import ophan.thrift.event.{AbTest, AcquisitionSource, Platform}
 import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
 
 // THIS CASE CLASS IS USED BY THE FRONTEND AND BY THE MOBILE APPS AS A JSON POST
@@ -28,9 +28,9 @@ case class ContributionRequest(
   componentId: Option[String],
   componentType: Option[ComponentType],
   source: Option[AcquisitionSource],
-  abTest: Option[AbTest], // Deprecated, should user referer and native AB test fields
   refererAbTest: Option[AbTest],
-  nativeAbTests: Option[Set[AbTest]]
+  nativeAbTests: Option[Set[AbTest]],
+  isSupport: Option[Boolean]
 )
 
 object ContributionRequest {

--- a/app/models/PaypalAcquisitionComponents.scala
+++ b/app/models/PaypalAcquisitionComponents.scala
@@ -45,7 +45,8 @@ object PaypalAcquisitionComponents {
       componentType: Option[ComponentType],
       source: Option[AcquisitionSource],
       refererAbTest: Option[AbTest],
-      nativeAbTests: Option[Set[AbTest]]
+      nativeAbTests: Option[Set[AbTest]],
+      isSupport: Option[Boolean]
     )
 
     implicit object paypalAcquisitionSubmissionBuilder extends PaypalAcquisitionSubmissionBuilder[Execute] {
@@ -73,7 +74,7 @@ object PaypalAcquisitionComponents {
             componentId = request.componentId,
             componentTypeV2 = request.componentType,
             source = request.source,
-            platform = Some(ophan.thrift.event.Platform.Contribution)
+            platform = Some(ophanPlatform(request.isSupport))
           )
         }
       }

--- a/app/models/StripeAcquisitionComponents.scala
+++ b/app/models/StripeAcquisitionComponents.scala
@@ -39,7 +39,7 @@ object StripeAcquisitionComponents {
           componentId = request.body.componentId,
           componentTypeV2 = request.body.componentType,
           source = request.body.source,
-          platform = Some(ophan.thrift.event.Platform.Contribution)
+          platform = Some(ophanPlatform(request.body.isSupport))
         )
       )
     }

--- a/app/services/ContributionOphanService.scala
+++ b/app/services/ContributionOphanService.scala
@@ -159,6 +159,11 @@ object ContributionOphanService extends LazyLogging {
       referrerAbTest.foreach(abTests += _)
       AbTestInfo(abTests)
     }
+
+    // isSupport field models optional boolean flag present in or derived from API requests.
+    protected def ophanPlatform(isSupport: Option[Boolean]): ophan.thrift.event.Platform =
+      if (isSupport.contains(true)) ophan.thrift.event.Platform.Support
+      else ophan.thrift.event.Platform.Contribution
   }
 }
 

--- a/app/utils/ThriftUtils.scala
+++ b/app/utils/ThriftUtils.scala
@@ -2,7 +2,7 @@ package utils
 
 import com.twitter.scrooge.ThriftEnum
 import ophan.thrift.componentEvent.ComponentType
-import ophan.thrift.event.{AbTest, AcquisitionSource, Platform}
+import ophan.thrift.event.{AbTest, AcquisitionSource}
 import play.api.data.FormError
 import play.api.data.format.Formatter
 import play.api.libs.json._

--- a/app/utils/ThriftUtils.scala
+++ b/app/utils/ThriftUtils.scala
@@ -2,7 +2,7 @@ package utils
 
 import com.twitter.scrooge.ThriftEnum
 import ophan.thrift.componentEvent.ComponentType
-import ophan.thrift.event.{AbTest, AcquisitionSource}
+import ophan.thrift.event.{AbTest, AcquisitionSource, Platform}
 import play.api.data.FormError
 import play.api.data.format.Formatter
 import play.api.libs.json._

--- a/test/forms/ContributionRequestSpec.scala
+++ b/test/forms/ContributionRequestSpec.scala
@@ -29,9 +29,9 @@ class ContributionRequestSpec extends PlaySpec with EitherValues {
     componentId = None,
     componentType = None,
     source = None,
-    abTest = None,
     refererAbTest = None,
-    nativeAbTests = None
+    nativeAbTests = None,
+    isSupport = None
   )
 
   val baseJson: JsObject =  Json.obj(
@@ -77,23 +77,17 @@ class ContributionRequestSpec extends PlaySpec with EitherValues {
 
     "be able to parse data successfully when ab test information is included" in {
 
-      val request = baseRequest.copy(abTest = Some(ophan.thrift.event.AbTest("name", "variant")))
+      val request = baseRequest.copy(refererAbTest = Some(ophan.thrift.event.AbTest("name", "variant")))
 
-      val json = baseJson ++ Json.obj("abTest" -> Json.obj("name" -> "name", "variant" -> "variant"))
+      val json = baseJson ++ Json.obj("refererAbTest" -> Json.obj("name" -> "name", "variant" -> "variant"))
 
       checkJson(request, json)
 
-      val request2 = baseRequest.copy(refererAbTest = Some(ophan.thrift.event.AbTest("name", "variant")))
+      val request2 = baseRequest.copy(nativeAbTests = Some(Set(ophan.thrift.event.AbTest("name", "variant"))))
 
-      val json2 = baseJson ++ Json.obj("refererAbTest" -> Json.obj("name" -> "name", "variant" -> "variant"))
+      val json2 = baseJson ++ Json.obj("nativeAbTests" -> Json.arr(Json.obj("name" -> "name", "variant" -> "variant")))
 
       checkJson(request2, json2)
-
-      val request3 = baseRequest.copy(nativeAbTests = Some(Set(ophan.thrift.event.AbTest("name", "variant"))))
-
-      val json3 = baseJson ++ Json.obj("nativeAbTests" -> Json.arr(Json.obj("name" -> "name", "variant" -> "variant")))
-
-      checkJson(request3, json3)
     }
   }
 }


### PR DESCRIPTION
#366 included the platform field in acquisition events, however, it didn't account for the fact that contributions frontend is also an API supporting support frontend and that in this case the platform should be recorded as support. 

This pull request looks to solve it as simply as possible. Things it __doesn't__ do:

- attempt to account for other platforms - in reality contributions frontend will only be used by support and the contributions website (... and the App, but this has always been regarded as part of the contributions platform).
- use the `platform` that is already included in some requests - this is used for other functionality and attempting to overload this field lead to confusing application code.

@svillafe I'll make a pull request on support frontend to include the `isSupport` field for Stripe payment requests.

Have you gone through the contributions flow for all test variants ? __Yes, tested locally with__ [#316](https://github.com/guardian/support-frontend/pull/316)
