### PR TITLE
Adding sbt-dependency-graph plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,3 +12,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.2")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
+
+// dependency tracker plugin - needed for snyk cli integration
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,4 +14,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.2")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
 
 // dependency tracker plugin - needed for snyk cli integration
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")


### PR DESCRIPTION
I am evaluating snyk.io to monitor dependencies vulnerabilities.
Snyk.io depends on the sbt-dependency-graph plugin

It is necessary to use CLI setup as the default configuration for Snyk (which goes directly to the public repository) does not pick up dev dependencies.


