### PR TITLE
catch paypal payments from support platform

### DIFF
--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -173,6 +173,10 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
       }
       info(s"Paypal payment from platform: ${request.platform} is successful. Contributions session id: ${request.sessionId}.")
       cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Paypal, request.platform)
+      if (supportRedirect.contains(true)) {
+        info(s"Redirecting user to support thank-you page. Payment method used: Paypal, platform: ${request.platform} , contributions session id: ${request.sessionId}.")
+        cloudWatchMetrics.logPaymentSuccessRedirected(PaymentProvider.Paypal, request.platform)
+      }
       response.setCookie[ContribTimestampCookieAttributes](payment.getCreateTime)
     }
 


### PR DESCRIPTION
This will catch requests from support platform that are being sent to the support.theguardian.com thank-you page.
Currently display of the thank-you page is not tracked for these transactions, which can add some confusion to our monitoring as it looks like they are not completing whereas they are in fact completely successful.

