### PR TITLE
[US gun campaign] less copy for tablet and mobile

### DIFF
--- a/app/views/fragments/giraffe/contributionsUSGunCampaign.scala.html
+++ b/app/views/fragments/giraffe/contributionsUSGunCampaign.scala.html
@@ -44,20 +44,13 @@
                     <div class="contributions__detail">
                         <div class="contributions__detail__para">
                             <hr />
+
                             <p>
-                                Meaningful solutions to America&#39;s gun violence epidemic are getting lost in a cycle of despair and outrage that define the media&#39;s response to gun tragedies. And nothing ever changes as a result.
+                                Meaningful solutions to America&#39;s gun violence epidemic are getting lost in a cycle of despair and outrage that define the media&#39;s response to gun tragedies.
                             </p>
 
                             <p>
-                                At the Guardian, we do not accept the orthodoxy that the debate about gun control is simply too difficult. Our new series, <a href="https://www.theguardian.com/us-news/series/break-the-cycle">Break the Cycle</a>, will challenge the way the media covers gun violence. It will drive an ongoing conversation about possible solutions, and  hold politicians to account for ignoring reforms that could save lives.
-                            </p>
-
-                            <p>
-                                To drive change in America, we need to recognize that gun rights advocates are important partners &mdash; and that citizens on all sides want to make the country safer. We will address gun violence in all its forms: not just mass shootings, but the more than 100 people killed daily in suicides, domestic violence, and accidental killings, and the disproportionate burden of gun violence on communities of color.
-                            </p>
-
-                            <p>
-                                By keeping the issue of gun violence in the public eye outside of major tragedies, we can keep the US and the world informed and create meaningful change.
+                                At the Guardian, we do not accept the orthodoxy that the debate about gun control is simply too difficult. Our new series, <a href="https://www.theguardian.com/us-news/series/break-the-cycle">Break the Cycle</a>, will challenge the way the media covers gun violence. It will drive an ongoing conversation about possible solutions, and hold politicians to account for ignoring reforms that could save lives.
                             </p>
 
                             <p>
@@ -65,15 +58,7 @@
                             </p>
 
                             <p>
-                                To participate in the conversation and meet the reporters involved, we invite you to join the Guardian’s Lois Beckett, Jamiles Lartey and Oliver Laughland for a live video chat on Facebook this Friday, November 17, at 12pm EST/9am PST/4pm GMT. You can <a href="https://www.facebook.com/GuardianUs/events/">submit questions in advance on our Facebook page</a>.
-                            </p>
-
-                            <p>
                                 If you have questions or comments about <a href="https://www.theguardian.com/us-news/series/break-the-cycle">Break the Cycle</a>, you can reach <a href="mailto:breakthecycle@@theguardian.com">reach us via email</a>.
-                            </p>
-
-                            <p>
-                                We&#39;re also seeking larger contributions to support the Guardian&#39;s reporting on gun violence  from foundations, companies and individuals. If you would like to get involved with this project or provide matching funds, please <a href="mailto:breakthecycle@@theguardian.com">contact us via email</a>.
                             </p>
                         </div>
                     </div>
@@ -96,7 +81,7 @@
                             </p>
 
                             <p>
-                                At the Guardian, we do not accept the orthodoxy that the debate about gun control is simply too difficult. Our new series, <a href="https://www.theguardian.com/us-news/series/break-the-cycle">Break the Cycle</a>, will challenge the way the media covers gun violence. It will drive an ongoing conversation about possible solutions, and  hold politicians to account for ignoring reforms that could save lives.
+                                At the Guardian, we do not accept the orthodoxy that the debate about gun control is simply too difficult. Our new series, <a href="https://www.theguardian.com/us-news/series/break-the-cycle">Break the Cycle</a>, will challenge the way the media covers gun violence. It will drive an ongoing conversation about possible solutions, and hold politicians to account for ignoring reforms that could save lives.
                             </p>
 
                             <p>
@@ -120,7 +105,7 @@
                             </p>
 
                             <p>
-                                We&#39;re also seeking larger contributions to support the Guardian&#39;s reporting on gun violence  from foundations, companies and individuals. If you would like to get involved with this project or provide matching funds, please <a href="mailto:breakthecycle@@theguardian.com">contact us via email</a>.
+                                We&#39;re also seeking larger contributions to support the Guardian&#39;s reporting on gun violence from foundations, companies and individuals. If you would like to get involved with this project or provide matching funds, please <a href="mailto:breakthecycle@@theguardian.com">contact us via email</a>.
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
Jane from US was concerned that on mobile and tablet the length of copy meant the payment form was too far below the line. This pull request reduces the copy on mobile and tablet to mitigate against this.

Have you gone through the contributions flow for all test variants ? __Yes__