### PR TITLE
Log payment amounts

### DIFF
--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -168,7 +168,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
           } else {
             routes.Contributions.postPayment(countryGroup).url
           }
-          info(s"Paypal payment from platform: ${request.platform} is successful. Contributions session id: ${request.sessionId}. Amount is $amount.")
+          info(s"Paypal payment from platform: ${request.platform} is successful. Contributions session id: ${request.sessionId}. Amount is ${amount.map(_.show).getOrElse("")}.")
           redirectWithCampaignCodes(redirectUrl).addingToSession(session: _ *)
       }
       cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Paypal, request.platform)

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -168,10 +168,9 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
           } else {
             routes.Contributions.postPayment(countryGroup).url
           }
-
+          info(s"Paypal payment from platform: ${request.platform} is successful. Contributions session id: ${request.sessionId}. Amount is $amount.")
           redirectWithCampaignCodes(redirectUrl).addingToSession(session: _ *)
       }
-      info(s"Paypal payment from platform: ${request.platform} is successful. Contributions session id: ${request.sessionId}.")
       cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Paypal, request.platform)
       if (supportRedirect.contains(true)) {
         info(s"Redirecting user to support thank-you page. Payment method used: Paypal, platform: ${request.platform} , contributions session id: ${request.sessionId}.")

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -126,12 +126,13 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
     }
 
     def logPaymentSuccess(charge: Stripe.Charge): Unit = {
-      val amount = charge.amount
+      val currency = charge.currency
+      val amount = contributionAmount.show
       if (request.isAndroid) {
-        info(s"Stripe payment successful for contributions session id: ${request.sessionId}. Amount is $amount - redirected to external platform for thank you page. platform is: ${request.platform}.")
+        info(s"Stripe payment successful for contributions session id: ${request.sessionId}. Amount is $amount. \n Redirected to external platform for thank you page. platform is: ${request.platform}.")
         cloudWatchMetrics.logPaymentSuccessRedirected(PaymentProvider.Stripe, request.platform)
       } else {
-        info(s"Stripe payment successful for contributions session id: ${request.sessionId}. Amount is $amount - sent from platform ${request.platform}")
+        info(s"Stripe payment successful for contributions session id: ${request.sessionId}. Amount is $amount. Sent from platform ${request.platform}")
         cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Stripe, request.platform)
       }
     }

--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -150,13 +150,13 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
         .withHeaders(corsHeaders(request): _*)
     }.recover {
       case e: Stripe.Error => {
-        warn(s"Payment failed for contributions session id: ${request.sessionId}, from platform: ${request.platform}, \n\t with code: ${e.decline_code} \n\t and message: ${e.message}.")
+        warn(s"Payment failed for contributions session id: ${request.sessionId}, from platform: ${request.platform}, \n\t for amount: ${contributionAmount.show}, \n\t with code: ${e.decline_code} \n\t and message: ${e.message}.")
         cloudWatchMetrics.logPaymentFailure(PaymentProvider.Stripe, request.platform)
         BadRequest(Json.toJson(e)).withHeaders(corsHeaders(request): _*)
       }
       case err => {
         cloudWatchMetrics.logUnhandledPaymentFailure(PaymentProvider.Stripe, request.platform)
-        warn(s"Payment failed: ${err.getMessage}. contributions session id: ${request.sessionId}, from platform: ${request.platform}")
+        warn(s"Payment failed: ${err.getMessage}. contributions session id: ${request.sessionId}, from platform: ${request.platform}, \n\t for amount: ${contributionAmount.show}")
         BadRequest(Json.toJson("unknown error")).withHeaders(corsHeaders(request): _*)
       }
     }


### PR DESCRIPTION
This change adds payment amount information to logging for payment success and - where possible - payment failure.

This is to make it easier to manually check the amounts of payments are as expected and to aid future investigations where users are unclear on how much they have paid.
