### PR TITLE
Remove Ophan call in payment flow

### DIFF
--- a/assets/javascripts/src/actions.es6
+++ b/assets/javascripts/src/actions.es6
@@ -3,7 +3,7 @@ import 'whatwg-fetch';
 import store from 'src/store';
 import { urls } from 'src/constants';
 import { trackCheckout, trackPayment } from 'src/modules/analytics/ga';
-import { completeTests, inStripeCheckoutTest } from 'src/modules/abTests';
+import { inStripeCheckoutTest } from 'src/modules/abTests';
 import * as stripe from 'src/modules/stripe';
 
 export const SET_DATA = "SET_DATA";

--- a/assets/javascripts/src/actions.es6
+++ b/assets/javascripts/src/actions.es6
@@ -57,7 +57,6 @@ export function processStripePayment(token) {
     })).then(response => {
         if (response.response.ok) {
             return trackPayment(state.card.amount, state.data.currency.code)
-                .then(completeTests)
                 .then(() => store.dispatch({type: PAYMENT_COMPLETE, response: response.json}))
                 .then(() => response);
         }
@@ -118,7 +117,6 @@ export function paypalRedirect(dispatch) {
     })
     .then(response => {
         return trackPayment(state.card.amount, state.data.currency.code)
-            .then(completeTests)
             .then(() => response);
     })
     .then((res) =>  window.location = res.approvalUrl)

--- a/assets/javascripts/src/modules/abTests.es6
+++ b/assets/javascripts/src/modules/abTests.es6
@@ -54,11 +54,6 @@ function registerTestWithOphan(test, complete) {
     return registerTestsWithOphan([test], complete);
 }
 
-export function completeTests() {
-    const state = store.getState();
-    return registerTestsWithOphan(state.data.abTests, true);
-}
-
 function testFor(tests, testName) {
     return tests && tests.find(t => t.testName == testName);
 }


### PR DESCRIPTION
This fixes the payment flow in IE11

In IE11, all Ophan requests are aborted by the browser. This means the promise which wraps `ophan.record` never resolves so the Stripe & PayPal flows never move on to the next step.

Since we don't need the complete information, we've just removed these calls