### PR TITLE
Stop sending marketing preferences to Stripe and Postgres

### DIFF
--- a/app/controllers/StripeController.scala
+++ b/app/controllers/StripeController.scala
@@ -55,7 +55,6 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
     val contributionId = ContributionId.random
 
     val metadata = Map(
-      "marketing-opt-in" -> form.marketing.toString,
       "email" -> form.email,
       "name" -> form.name,
       "abTests" -> Json.toJson(request.testAllocations).toString,
@@ -97,7 +96,6 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
         created = new DateTime(charge.created * 1000L),
         name = form.name,
         postCode = form.postcode,
-        marketing = form.marketing,
         testAllocations = request.testAllocations,
         cmp = form.cmp,
         intCmp = form.intcmp,
@@ -119,8 +117,7 @@ class StripeController(paymentServices: PaymentServices, stripeConfig: Config, c
         metadata = metadata.contributionMetadata,
         contributor = metadata.contributor,
         contributorRow = metadata.contributorRow,
-        idUser = idUser,
-        marketing = form.marketing
+        idUser = idUser
       )
     }
 

--- a/app/controllers/forms/ContributionRequest.scala
+++ b/app/controllers/forms/ContributionRequest.scala
@@ -15,7 +15,6 @@ case class ContributionRequest(
   amount: BigDecimal,
   email: String,
   token: String,
-  marketing: Boolean,
   postcode: Option[String],
   ophanPageviewId: String,
   ophanBrowserId: Option[String],

--- a/app/data/ContributionData.scala
+++ b/app/data/ContributionData.scala
@@ -122,7 +122,6 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) extends TagA
           lastname,
           iduser,
           postcode,
-          marketingoptin,
           contributor_id,
           updated
         ) VALUES (
@@ -132,7 +131,6 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) extends TagA
           ${contributor.lastName},
           ${contributor.idUser.map(_.id)},
           ${contributor.postCode},
-          ${contributor.marketingOptIn},
           ${contributor.contributorId.map(_.id)}::uuid,
           now()
         ) ON CONFLICT(receipt_email) DO
@@ -143,7 +141,6 @@ class ContributionData(db: Database)(implicit ec: ExecutionContext) extends TagA
           lastname = COALESCE(excluded.lastname, live_contributors.lastname),
           iduser = COALESCE(excluded.iduser, live_contributors.iduser),
           postcode = COALESCE(excluded.postcode, live_contributors.postcode),
-          marketingoptin = COALESCE(excluded.marketingoptin, live_contributors.marketingoptin),
           updated = now()"""
       request.execute()
       contributor

--- a/app/models/Contributor.scala
+++ b/app/models/Contributor.scala
@@ -15,6 +15,5 @@ case class Contributor(
   firstName: Option[String],
   lastName: Option[String],
   idUser: Option[IdentityId],
-  postCode: Option[String],
-  marketingOptIn: Option[Boolean]
+  postCode: Option[String]
 )

--- a/app/services/PaypalService.scala
+++ b/app/services/PaypalService.scala
@@ -245,8 +245,7 @@ class PaypalService(
         firstName = firstName,
         lastName = lastName,
         idUser = idUser,
-        postCode = postCode,
-        marketingOptIn = None
+        postCode = postCode
       )
 
       val contributorRow = ContributorRow(

--- a/app/services/StripeService.scala
+++ b/app/services/StripeService.scala
@@ -33,7 +33,6 @@ class StripeService(
     created: DateTime,
     name: String,
     postCode: Option[String],
-    marketing: Boolean,
     testAllocations: Set[Allocation],
     cmp: Option[String],
     intCmp: Option[String],
@@ -69,8 +68,7 @@ class StripeService(
       firstName = None,
       lastName = None,
       idUser = idUser,
-      postCode = postCode,
-      marketingOptIn = Some(marketing)
+      postCode = postCode
     )
 
     val contributorRow = ContributorRow(
@@ -92,8 +90,7 @@ class StripeService(
     metadata: ContributionMetaData,
     contributor: Contributor,
     contributorRow: ContributorRow,
-    idUser: Option[IdentityId],
-    marketing: Boolean)
+    idUser: Option[IdentityId])
     (implicit tags: LoggingTags): EitherT[Future, String, SavedContributionData] = {
       emailService.thank(contributorRow)
 

--- a/assets/javascripts/src/actions.es6
+++ b/assets/javascripts/src/actions.es6
@@ -147,7 +147,6 @@ function paymentFormData(state, token) {
         amount: state.card.amount,
         email: state.details.email,
         token: token,
-        marketing: state.details.optIn,
         postcode: state.details.postcode,
         ophanPageviewId: state.data.ophan.pageviewId,
         ophanBrowserId: state.data.ophan.browserId,

--- a/test/forms/ContributionRequestSpec.scala
+++ b/test/forms/ContributionRequestSpec.scala
@@ -15,7 +15,6 @@ class ContributionRequestSpec extends PlaySpec with EitherValues {
     amount = 10,
     email = "test@gmail.com",
     token = "token",
-    marketing = true,
     postcode = None,
     ophanPageviewId = "pageviewId",
     ophanBrowserId = None,
@@ -40,7 +39,6 @@ class ContributionRequestSpec extends PlaySpec with EitherValues {
     "amount" -> "10.0",
     "email" -> "test@gmail.com",
     "token" -> "token",
-    "marketing" -> true,
     "ophanPageviewId" -> "pageviewId"
   )
 
@@ -74,6 +72,17 @@ class ContributionRequestSpec extends PlaySpec with EitherValues {
 
       checkJson(request, json)
     }
+
+    "be able to parse data successfully when marketing information is included" in {
+
+      val request = baseRequest
+
+      val json = baseJson ++ Json.obj("marketing" -> "true")
+
+      checkJson(request, json)
+    }
+
+
 
     "be able to parse data successfully when ab test information is included" in {
 


### PR DESCRIPTION
Consent to receiving marketing is now taken and stored through Identity. This means that we should not be sending marketing preference to Stripe, Paypal or Postgres. 