### PR TITLE
Add skeleton for Australia environment campaign

### DIFF
--- a/app/views/fragments/giraffe/contributionsAusEnvironmentCampaign.scala.html
+++ b/app/views/fragments/giraffe/contributionsAusEnvironmentCampaign.scala.html
@@ -1,0 +1,125 @@
+@import com.gu.i18n.CountryGroup
+@import views.support.PageInfo
+@import views.support.CountryGroupImplicits._
+@import abtests.Allocation
+
+@(pageInfo: PageInfo = views.support.PageInfo(),
+    countryGroup: CountryGroup,
+    maxAmount: Option[Int] = None,
+    mainScript: Option[String] = None,
+    errorMessage:Option[String])(content: Html)
+
+@main(pageInfo, Some(countryGroup), maxAmount, mainScript) {
+    <div class="contributions--aus-campaign">
+        <section class="contributions__banner">
+            <div class="l-constrained"></div>
+        </section>
+
+        <main class="contributions__wrapper currency-@countryGroup.currency.toString.toLowerCase">
+
+            @for(message <- errorMessage) {
+                <div id="errorDialog" class="overlay">
+                    <div>
+                        <h1 class="errorHeader">We're sorry</h1>
+                        <p class="errorMessage">@message</p>
+                        <button class="action action--button contribute-navigation__next" id="errorDialogButton">OK</button>
+
+                    </div>
+                </div>
+            }
+
+            <section class="contributions__inner page-slice l-constrained flex-horizontal-from-tablet">
+                <div class="contributions__inner-wrapper">
+                    <hgroup class="contributions__heading">
+                        <h1 class="contributions__heading--main">
+                            <span>Support an in-depth series on</span> <br />
+                            <span class="heading-line--indent-max">the environment</span>
+                        </h1>
+
+                        <h2 class="contributions__heading--sub">
+                            <span>Make a contribution</span> <br />
+                            <span class="sub-heading-line--indent">and help us raise $100,000</span>
+                        </h2>
+                    </hgroup>
+                    <div class="contributions__detail">
+                        <div class="contributions__detail__para">
+                            <hr />
+
+                            <p>
+                                Meaningful solutions to America&#39;s gun violence epidemic are getting lost in a cycle of despair and outrage that define the media&#39;s response to gun tragedies.
+                            </p>
+
+                            <p>
+                                At the Guardian, we do not accept the orthodoxy that the debate about gun control is simply too difficult. Our new series, <a href="https://www.theguardian.com/us-news/series/break-the-cycle">Break the Cycle</a>, will challenge the way the media covers gun violence. It will drive an ongoing conversation about possible solutions, and hold politicians to account for ignoring reforms that could save lives.  Your support will fund our in-depth reporting on guns throughout 2018.
+                            </p>
+
+                            <p>
+                                If you have questions or comments about <a href="https://www.theguardian.com/us-news/series/break-the-cycle">Break the Cycle</a>, you can <a href="mailto:breakthecycle@@theguardian.com">reach us via email</a>.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                @content
+            </section>
+        </main>
+
+        <section id="ticker" data-src='https://interactive.guim.co.uk/docsdata-test/1kxq0b0E4BfoYmevQuAoG-V6Bk6CEJsuVqwKHdosh66A.json'></section>
+
+        <section class="disclaimer">
+            <div class="support-wrapper page-slice page-slice__feedback l-constrained currency-@countryGroup.currency.toString.toLowerCase">
+                <div class="feedback">
+
+                    <div class="contributions__detail">
+                        <div class="contributions__detail__para">
+                            <p>
+                                Meaningful solutions to America&#39;s gun violence epidemic are getting lost in a cycle of despair and outrage that define the media&#39;s response to gun tragedies. And nothing ever changes as a result.
+                            </p>
+
+                            <p>
+                                At the Guardian, we do not accept the orthodoxy that the debate about gun control is simply too difficult. Our new series, <a href="https://www.theguardian.com/us-news/series/break-the-cycle">Break the Cycle</a>, will challenge the way the media covers gun violence. It will drive an ongoing conversation about possible solutions, and hold politicians to account for ignoring reforms that could save lives. Your support will fund our in-depth reporting on guns throughout 2018.
+                            </p>
+
+                            <p>
+                                To drive change in America, we need to recognize that gun rights advocates are important partners &mdash; and that citizens on all sides want to make the country safer. We will address gun violence in all its forms: not just mass shootings, but the more than 100 people killed daily in suicides, domestic violence, and accidental killings, and the disproportionate burden of gun violence on communities of color.
+                            </p>
+
+                            <p>
+                                By keeping the issue of gun violence in the public eye outside of major tragedies, we can keep the US and the world informed and create meaningful change.
+                            </p>
+
+                            <p>
+                                If you have questions or comments about <a href="https://www.theguardian.com/us-news/series/break-the-cycle">Break the Cycle</a>, you can <a href="mailto:breakthecycle@@theguardian.com">reach us via email</a>. We&#39;re also seeking larger contributions to support the Guardian&#39;s reporting on gun violence from foundations, companies and individuals. If you would like to get involved with this project or provide matching funds, please <a href="mailto:breakthecycle@@theguardian.com">contact us via email</a>.
+                            </p>
+                        </div>
+                    </div>
+
+                    <hr />
+
+                    <p>
+                        If we hit our goal, the Guardian will allocate $100,000 to its core operations that will fund our extended coverage of gun violence in America, including editing, reporting, visuals and new commissions. If we exceed our fundraising target, the Guardian will allocate additional funds towards its core operations that fund our in-depth reporting on topics including national affairs, politics, criminal justice, and gun violence. If we fall short of the target, the Guardian will allocate funds for a scaled back project on gun violence. Contributions will not be returned. You can read additional <a href="https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions">terms and conditions here</a>.
+                    </p>
+
+                    <p>
+                        The ultimate owner of the Guardian is the Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism.
+                    </p>
+
+                    <p data-shown="gbp aud eur">
+                        Please note that the Guardian is not a charity, will not use your support for charitable programs, and your support of the Guardian’s journalism does not constitute a charitable donation. As such your contribution is not eligible to be treated as a charitable deduction for federal or state taxes in the United States or elsewhere.
+                    </p>
+
+                    <p data-shown="usd">
+                        Please note that the Guardian is not a charity, will not use your support for charitable
+                        programs, and your support of the Guardian’s journalism does not constitute a
+                        charitable donation. As such your contribution is not eligible to be treated as a
+                        charitable deduction for federal or state taxes in the United States or elsewhere.
+                    </p>
+
+                    <p>
+                        If you have any questions about contributing to the Guardian, please <a href="mailto:contribution.support@@theguardian.com" class="support-thanks__link">contact us here</a>.
+                    </p>
+                </div>
+            </div>
+        </section>
+    </div>
+}

--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -1,6 +1,6 @@
 @import abtests._
 @import com.gu.i18n.CountryGroup
-@import fragments.giraffe.{contributionsMain, contributionsAlt, contributionsUSGunCampaign, contributionsMotherLoadCampaign}
+@import fragments.giraffe.{contributionsMain, contributionsAlt, contributionsUSGunCampaign, contributionsMotherLoadCampaign, contributionsAusEnvironmentCampaign}
 @import play.api.libs.json.Json
 @import utils.ThriftEnumFormatter.ops._
 @import utils.ThriftUtils.Implicits._
@@ -31,12 +31,17 @@
 )
 
 @defining { (block: Html) =>
-    @if(intCmpCode.contains("us_gun_campaign_2017")) {
-        @contributionsUSGunCampaign(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)
-    } else {
-        @if(intCmpCode.contains("us_mother_load_campaign_2017")) {
+    @intCmpCode match {
+        case Some("aus_environment_campaign_2018") => {
+            @contributionsAusEnvironmentCampaign(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)
+        }
+        case Some("us_gun_campaign_2017") => {
+            @contributionsUSGunCampaign(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)
+        }
+        case Some("us_mother_load_campaign_2017") => {
             @contributionsMotherLoadCampaign(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)
-        } else {
+        }
+        case _ => {
             @if(inLandingPageTest) {
                 @contributionsAlt(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)
             } else {

--- a/assets/stylesheets/contributions.scss
+++ b/assets/stylesheets/contributions.scss
@@ -838,3 +838,136 @@ $currencies: gbp usd aud eur nzd cad;
         }
     }
 }
+
+.contributions--aus-campaign {
+    .contributions__wrapper {
+        .contributions__inner {
+            overflow: visible;
+            position: relative;
+            padding: 0 10px 20px;
+
+            @include mq(mobileLandscape) {
+                padding: 0 20px 20px;
+            }
+
+            @include mq(desktop) {
+                padding-bottom: 0;
+            }
+        }
+
+        .contribute-container {
+            @include mq(desktop) {
+                position: absolute;
+                top: -92px;
+                right: 20px;
+            }
+
+            &:after {
+                content: 'We prefer to collect contributions online. However, if you wish to mail us your contribution, please send checks to: 315 West 36th St., 8th Floor, New York, NY 10018';
+                display: block;
+                margin-top: 8px;
+                font-family: 'Guardian Text Sans Web';
+                font-size: 13px;
+                line-height: 18px;
+                color: $c-neutral2;
+            }
+        }
+
+        .contributions__heading {
+            margin-top: 0;
+            padding-top: 12px;
+        }
+
+        .heading-line--indent-max {
+            padding-left: 0;
+
+            @include mq(desktop) {
+                padding-left: 140px;
+            }
+        }
+
+        .sub-heading-line--indent {
+            @include mq($until: tablet) {
+                padding-left: 0;
+            }
+        }
+
+        .contributions__detail {
+            @include mq(desktop) {
+                display: none;
+            }
+
+            .contributions__detail__para {
+                a {
+                    color: white;
+                    border-bottom-color: white;
+                }
+            }
+        }
+    }
+
+    .disclaimer {
+        .l-constrained {
+            padding-top: 12px;
+        }
+
+        .feedback {
+            padding: 0 20px;
+        }
+
+        .contributions__detail__para {
+            display: none;
+
+            @include mq(desktop) {
+                display: block;
+            }
+
+            a {
+                color: $medium-yellow;
+                border-bottom-color: $medium-yellow;
+
+                &:hover {
+                    border-bottom-color: $c-neutral1;
+                }
+            }
+        }
+
+        hr {
+            width: 120px;
+            border: 0;
+            height: 1px;
+            background-color: $c-neutral1;
+            margin: 22px 0 4px;
+
+            @include mq($until: desktop) {
+                display: none;
+            }
+        }
+
+        .feedback > p {
+            max-width: 620px;
+            color: $c-neutral2;
+
+            a {
+                color: $medium-yellow;
+                border-bottom-color: $medium-yellow;
+
+                &:hover {
+                    border-bottom-color: $c-neutral1;
+                }
+            }
+        }
+    }
+
+    .contributions__detail__para {
+        font-family: 'Guardian Text Egyptian Web', Georgia, serif;
+        max-width: 620px;
+        width: 100%;
+        font-size: 16px;
+        line-height: 1.5rem;
+
+        @include mq(tablet) {
+            padding-right: 60px;
+        }
+    }
+}


### PR DESCRIPTION
Adds a new landing page, currently basically the same as the US gun campaign but to be modified by the team in Australia

Add param `INTCMP=aus_environment_campaign_2018` to get this page