### PR TITLE
add an eventually and a timeout to the StoreMetaData checker

### DIFF
--- a/test/controllers/PaypalControllerSpec.scala
+++ b/test/controllers/PaypalControllerSpec.scala
@@ -22,14 +22,15 @@ import services.{ContributionOphanService, PaymentServices, PaypalService}
 import cats.instances.future._
 import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
 import org.mockito.internal.verification.VerificationModeFactory
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.time.{Millis, Seconds, Span}
 import play.api.libs.json.Json
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
-class PaypalControllerFixture(implicit ec: ExecutionContext) extends MockitoSugar {
+class PaypalControllerFixture(implicit ec: ExecutionContext) extends MockitoSugar with Eventually {
 
   val mockPaymentServices: PaymentServices = mock[PaymentServices]
 
@@ -46,6 +47,8 @@ class PaypalControllerFixture(implicit ec: ExecutionContext) extends MockitoSuga
   val mockOphanService = mock[ContributionOphanService]
 
   val supportConfig = SupportConfig("https://support.thegulocal.com/thankyou")
+
+
 
   Mockito.when(mockPaymentServices.paypalServiceFor(Matchers.any[Request[_]]))
     .thenReturn(mockPaypalService)
@@ -80,22 +83,24 @@ class PaypalControllerFixture(implicit ec: ExecutionContext) extends MockitoSuga
   val controller: PaypalController = new PaypalController(mockPaymentServices, mockCorsConfig, supportConfig, mockCsrfCheck, mockCloudwatchMetrics, mockOphanService)
 
   def numberOfCallsToStoreMetaDataMustBe(times: Int): Unit = {
-    def captor[A <: AnyRef](implicit classTag: ClassTag[A]): A =
-      ArgumentCaptor.forClass[A](classTag.runtimeClass.asInstanceOf[Class[A]]).capture()
+    eventually(timeout(Span(60, Seconds)), interval(Span(1, Seconds))) {
+      def captor[A <: AnyRef](implicit classTag: ClassTag[A]): A =
+        ArgumentCaptor.forClass[A](classTag.runtimeClass.asInstanceOf[Class[A]]).capture()
 
-    Mockito.verify(mockPaypalService, VerificationModeFactory.times(times)).storeMetaData(
-      captor[Payment],
-      captor[Set[Allocation]],
-      captor[Option[String]],
-      captor[Option[String]],
-      captor[Option[String]],
-      captor[Option[String]],
-      captor[Option[String]],
-      captor[Option[String]],
-      captor[Option[IdentityId]],
-      captor[Option[String]],
-      captor[Option[String]]
-    )(captor[LoggingTags])
+      Mockito.verify(mockPaypalService, VerificationModeFactory.times(times)).storeMetaData(
+        captor[Payment],
+        captor[Set[Allocation]],
+        captor[Option[String]],
+        captor[Option[String]],
+        captor[Option[String]],
+        captor[Option[String]],
+        captor[Option[String]],
+        captor[Option[String]],
+        captor[Option[IdentityId]],
+        captor[Option[String]],
+        captor[Option[String]]
+      )(captor[LoggingTags])
+    }
   }
 
   def numberOfAcquisitionEventSubmissionsShouldBe(times: Int): Unit =
@@ -223,7 +228,7 @@ class PaypalControllerSpec extends PlaySpec
       val result: Future[Result] = Helpers.call(fixture.controller.capturePayment, captureRequest)
       status(result).mustBe(200)
 
-      fixture.numberOfCallsToStoreMetaDataMustBe(1)
+      Eventually.eventually(timeout(Span(5, Seconds)), interval(Span(50, Millis))) {fixture.numberOfCallsToStoreMetaDataMustBe(1)}
     }
 
     "capture a payment even if storing the metadata failed" in {

--- a/test/controllers/PaypalControllerSpec.scala
+++ b/test/controllers/PaypalControllerSpec.scala
@@ -48,8 +48,6 @@ class PaypalControllerFixture(implicit ec: ExecutionContext) extends MockitoSuga
 
   val supportConfig = SupportConfig("https://support.thegulocal.com/thankyou")
 
-
-
   Mockito.when(mockPaymentServices.paypalServiceFor(Matchers.any[Request[_]]))
     .thenReturn(mockPaypalService)
 
@@ -82,11 +80,11 @@ class PaypalControllerFixture(implicit ec: ExecutionContext) extends MockitoSuga
 
   val controller: PaypalController = new PaypalController(mockPaymentServices, mockCorsConfig, supportConfig, mockCsrfCheck, mockCloudwatchMetrics, mockOphanService)
 
+  def captor[A <: AnyRef](implicit classTag: ClassTag[A]): A =
+    ArgumentCaptor.forClass[A](classTag.runtimeClass.asInstanceOf[Class[A]]).capture()
+
   def numberOfCallsToStoreMetaDataMustBe(times: Int): Unit = {
     eventually(timeout(Span(60, Seconds)), interval(Span(1, Seconds))) {
-      def captor[A <: AnyRef](implicit classTag: ClassTag[A]): A =
-        ArgumentCaptor.forClass[A](classTag.runtimeClass.asInstanceOf[Class[A]]).capture()
-
       Mockito.verify(mockPaypalService, VerificationModeFactory.times(times)).storeMetaData(
         captor[Payment],
         captor[Set[Allocation]],
@@ -228,7 +226,7 @@ class PaypalControllerSpec extends PlaySpec
       val result: Future[Result] = Helpers.call(fixture.controller.capturePayment, captureRequest)
       status(result).mustBe(200)
 
-      Eventually.eventually(timeout(Span(5, Seconds)), interval(Span(50, Millis))) {fixture.numberOfCallsToStoreMetaDataMustBe(1)}
+      fixture.numberOfCallsToStoreMetaDataMustBe(1)
     }
 
     "capture a payment even if storing the metadata failed" in {


### PR DESCRIPTION
Attempt to resolve acceptance test failures issue described in https://trello.com/c/v1NXxFH1/35-intermittent-test-failure-on-contribute-site.

Problem is that storing metadata happens in a separate thread, but we don't wait at all before checking its value. This can introduce a race-condition if the storing metadata process has not completed before we check it, giving us random test failures.

This change modifies the acceptance tests - wrapping the method that checks the storeMetadata process in an Eventually with a timeout of 60 seconds and an interval of 1 second.
This will check every second for the storeMetadata value to return for 60 seconds.

Acceptance tests checked and ran successfully. 

