### PR TITLE
Drop gu.email cookie on .theguardian domain for paypal payments coming from support

### DIFF
--- a/app/cookies/CookieAttributes.scala
+++ b/app/cookies/CookieAttributes.scala
@@ -27,5 +27,7 @@ object Cookies {
   object MaxAge {
 
     val `10years` = 60 * 60 * 24 * 365 * 10
+
+    val `1day` = 60 * 60 * 24
   }
 }

--- a/app/cookies/GuEmailCookieAttributes.scala
+++ b/app/cookies/GuEmailCookieAttributes.scala
@@ -1,0 +1,24 @@
+package cookies
+
+import configuration.Config
+
+/**
+ * Should be set when a user contributes to the Guardian.
+ */
+trait GuEmailCookieAttributes extends CookieAttributes {
+
+  override val name: String = "gu.email"
+
+  override val maxAge: Option[Int] = None
+
+  /**
+   * If in production, the guardian domain is used, so that the cookie will be accessible from
+   * e.g. theguardian.com, contribute.theguardian.com
+   */
+  override val domain: Option[String] = if (Config.stageProd) Some(Config.guardianDomain) else Config.domain.map(_.stripPrefix("contribute"))
+}
+
+object GuEmailCookieAttributes {
+  implicit object guEmailCookieAttributes extends GuEmailCookieAttributes
+}
+


### PR DESCRIPTION
In order for us to be able to store the marketing preferences of contributors paying with PayPal on 
`support.theguardian.com`, the thank you page of that site needs to know the users email address. This PR drops a cookie with the users email address when completing their paypal payment (only for users who paid on support.theguardian.com)

