### PR TITLE
Forward all query string params on redirect

### DIFF
--- a/app/controllers/Contributions.scala
+++ b/app/controllers/Contributions.scala
@@ -43,7 +43,7 @@ class Contributions(paymentServices: PaymentServices, addToken: CSRFAddToken, cl
   def redirectToUk = (NoCacheAction andThen MobileSupportAction) { implicit request => redirectWithQueryParams(routes.Contributions.contribute(UK).url) }
 
   private def redirectWithQueryParams(destinationUrl: String)(implicit request: Request[Any]) =
-    redirectWithCampaignCodes(destinationUrl, Set("mcopy", "skipAmount", "highlight", "disableStripe", ReferrerAcquisitionData.queryStringKey))
+    redirectWithQueryString(destinationUrl)
 
   def postPayment(countryGroup: CountryGroup) = NoCacheAction.andThen(MetaDataAction.default) { implicit request =>
     val pageInfo = PageInfo(

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -164,7 +164,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
           val redirectUrl = routes.Contributions.postPayment(countryGroup).url
 
           info(s"Paypal payment from platform: ${request.platform} is successful. Contributions session id: ${request.sessionId}. Amount is ${amount.map(_.show).getOrElse("")}.")
-          redirectWithQueryString(redirectUrl).addingToSession(session: _ *)
+          redirect(redirectUrl).addingToSession(session: _ *)
       }
       cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Paypal, request.platform)
       if (supportRedirect.contains(true)) {

--- a/app/controllers/PaypalController.scala
+++ b/app/controllers/PaypalController.scala
@@ -164,7 +164,7 @@ class PaypalController(paymentServices: PaymentServices, corsConfig: CorsConfig,
           val redirectUrl = routes.Contributions.postPayment(countryGroup).url
 
           info(s"Paypal payment from platform: ${request.platform} is successful. Contributions session id: ${request.sessionId}. Amount is ${amount.map(_.show).getOrElse("")}.")
-          redirectWithCampaignCodes(redirectUrl).addingToSession(session: _ *)
+          redirectWithQueryString(redirectUrl).addingToSession(session: _ *)
       }
       cloudWatchMetrics.logPaymentSuccess(PaymentProvider.Paypal, request.platform)
       if (supportRedirect.contains(true)) {

--- a/app/controllers/Redirect.scala
+++ b/app/controllers/Redirect.scala
@@ -7,6 +7,10 @@ import play.api.mvc.{Controller, Request}
 
 trait Redirect {
   self: Controller =>
+  def redirect(destinationUrl: String)(implicit request: Request[Any]) = {
+    Redirect(destinationUrl, SEE_OTHER)
+  }
+
   def redirectWithQueryString(destinationUrl: String)(implicit request: Request[Any]) = {
     Redirect(destinationUrl, request.queryString, SEE_OTHER)
   }

--- a/app/controllers/Redirect.scala
+++ b/app/controllers/Redirect.scala
@@ -7,9 +7,8 @@ import play.api.mvc.{Controller, Request}
 
 trait Redirect {
   self: Controller =>
-  def redirectWithCampaignCodes(destinationUrl: String, additionalParams: Set[String] = Set.empty)(implicit request: Request[Any]) = {
-    val queryParamsToForward = Set("INTCMP", "CMP", "REFPVID", "platform", "amount") ++ additionalParams
-    Redirect(destinationUrl, request.queryString.filterKeys(queryParamsToForward), SEE_OTHER)
+  def redirectWithQueryString(destinationUrl: String)(implicit request: Request[Any]) = {
+    Redirect(destinationUrl, request.queryString, SEE_OTHER)
   }
 
   def mobileRedirectUrl(amount: ContributionAmount): String = {


### PR DESCRIPTION
I can't think of a reason why we don't do this already (support-frontend does https://github.com/guardian/support-frontend/blob/master/app/controllers/Application.scala#L37)

It would let us preserve GA params and other useful things that might let us infer important information when our own tracking falls short