### PR TITLE
Update current and new contributions databases at once

### DIFF
--- a/app/data/ContributionData.scala
+++ b/app/data/ContributionData.scala
@@ -38,7 +38,7 @@ class CurrentAndNewContributionData(currentDB: ContributionDataInstance, newDB: 
   }
 }
 
-class ContributionDataInstance(db: Database)(implicit ec: ExecutionContext) extends ContributionData with TagAwareLogger {
+class ContributionDataInstance(db: Database, paymentProviderType: String, paymentStatusType: String)(implicit ec: ExecutionContext) extends ContributionData with TagAwareLogger {
 
   def withAsyncConnection[A](autocommit: Boolean = false)(block: Connection => A)(implicit tags: LoggingTags): EitherT[Future, String, A] = EitherT(Future {
     val result = Try(db.withConnection(autocommit)(block))
@@ -66,12 +66,12 @@ class ContributionDataInstance(db: Database)(implicit ec: ExecutionContext) exte
         ) VALUES (
           ${paymentHook.contributionId.id}::uuid,
           ${paymentHook.paymentId},
-          ${paymentHook.provider}::paymentProvider,
+          ${paymentHook.provider}::#$paymentProviderType,
           ${paymentHook.created},
           ${paymentHook.currency},
           ${paymentHook.amount},
           ${paymentHook.convertedAmount},
-          ${paymentHook.status}::paymentStatus,
+          ${paymentHook.status}::#$paymentStatusType,
           ${paymentHook.email}
         ) ON CONFLICT(contributionId) DO
         UPDATE SET

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -8,7 +8,7 @@ import com.gu.monitoring.ServiceMetrics
 import com.softwaremill.macwire._
 import com.typesafe.config.ConfigFactory
 import controllers._
-import data.ContributionData
+import data.{ContributionData, CurrentAndNewContributionData, ContributionDataInstance}
 import filters.CheckCacheHeadersFilter
 import models.PaymentMode
 import play.api.mvc.EssentialFilter
@@ -45,8 +45,11 @@ trait AppComponents extends PlayComponents with GzipFilterComponents {
   val contributionDataPerMode: Map[PaymentMode, ContributionData] = {
     val dbConfig = config.getConfig("dbConf")
     def contributionDataFor(mode: PaymentMode) = {
-      val modeKey = dbConfig.getString(mode.entryName.toLowerCase)
-      new ContributionData(dbApi.database(modeKey))(jdbcExecutionContext) // explicit execution context to avoid blocking the app
+      val postgresModeKey = dbConfig.getString(s"${mode.entryName.toLowerCase}")
+      val auroraModeKey = s"${dbConfig.getString(s"${mode.entryName.toLowerCase}")}_aurora"
+      new CurrentAndNewContributionData(
+        new ContributionDataInstance(dbApi.database(postgresModeKey))(jdbcExecutionContext), // explicit execution context to avoid blocking the app
+        new ContributionDataInstance(dbApi.database(auroraModeKey))(jdbcExecutionContext)) // explicit execution context to avoid blocking the app
     }
     PaymentMode.values.map(mode => mode -> contributionDataFor(mode)).toMap
   }
@@ -64,7 +67,7 @@ trait AppComponents extends PlayComponents with GzipFilterComponents {
     identityService = identityService,
     emailService = emailService,
     regionalStripeService = regionalStripeService,
-    contributionDataPerMode = contributionDataPerMode,
+    contributionDataPerMode= contributionDataPerMode,
     actorSystem = actorSystem
   )
 

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -45,11 +45,11 @@ trait AppComponents extends PlayComponents with GzipFilterComponents {
   val contributionDataPerMode: Map[PaymentMode, ContributionData] = {
     val dbConfig = config.getConfig("dbConf")
     def contributionDataFor(mode: PaymentMode) = {
-      val postgresModeKey = dbConfig.getString(s"${mode.entryName.toLowerCase}")
+      val postgresModeKey = dbConfig.getString(mode.entryName.toLowerCase)
       val auroraModeKey = s"${dbConfig.getString(s"${mode.entryName.toLowerCase}")}_aurora"
       new CurrentAndNewContributionData(
-        new ContributionDataInstance(dbApi.database(postgresModeKey))(jdbcExecutionContext), // explicit execution context to avoid blocking the app
-        new ContributionDataInstance(dbApi.database(auroraModeKey))(jdbcExecutionContext)) // explicit execution context to avoid blocking the app
+        new ContributionDataInstance(dbApi.database(postgresModeKey), "paymentprovider", "paymentstatus")(jdbcExecutionContext), // explicit execution context to avoid blocking the app
+        new ContributionDataInstance(dbApi.database(auroraModeKey), "public.paymentprovider", "public.paymentstatus")(jdbcExecutionContext)) // explicit execution context to avoid blocking the app
     }
     PaymentMode.values.map(mode => mode -> contributionDataFor(mode)).toMap
   }


### PR DESCRIPTION
We are migrating our contributions store from PostGres to Aurora. Step one of this migration process is to update both the current DB and the new DB. This PR implements this.

The only difference in inserting into the new Aurora database is that custom types have to be referenced by `public.<custom type>`, rather than just `<custom type>`. This is why we have to instantiate the ContributionDataInstance with `public.paymentprovider` and `public.paymentstatus` for the Aurora instance, and  just `paymentprovider` and `paymentstatus` for the current postgres database

Once we have estabilshed that the new instance is working correctly, we can revert to just updating one database.

This change involves a change to the config. The `db` config will now have an extra config called [TEST/LIVE]_aurora, which contains the config of the new database.

Therefore, before merging, the config files for CODE, PROD and DEV need updating. As this config change is additive, it is a non-breaking change (i.e the current build of master works with the new config) 


Big shout out to @Mullefa who suggested I implement this with traits, which made the solution far more elegant