### PR TITLE
Add SSM role to cloudformation

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -98,6 +98,7 @@
       Type: AWS::IAM::Role
       Properties:
         Path: "/"
+        ManagedPolicyArns: [ "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM" ]
         AssumeRolePolicyDocument:
           Statement:
             - Effect: Allow


### PR DESCRIPTION
This is so we can log onto our instances using ssm: https://github.com/guardian/ssm-scala

@guardian/contributions