### PR TITLE
Switch off US campaigns

### DIFF
--- a/app/views/giraffe/contribute.scala.html
+++ b/app/views/giraffe/contribute.scala.html
@@ -35,12 +35,6 @@
         case Some("aus_environment_campaign_2018") => {
             @contributionsAusEnvironmentCampaign(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)
         }
-        case Some("us_gun_campaign_2017") => {
-            @contributionsUSGunCampaign(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)
-        }
-        case Some("us_mother_load_campaign_2017") => {
-            @contributionsMotherLoadCampaign(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)
-        }
         case _ => {
             @if(inLandingPageTest) {
                 @contributionsAlt(pageInfo, countryGroup, Some(maxAmount), Some("contributePage.js"), errorMessage)(block)


### PR DESCRIPTION
Turn off the special templates for campaign codes `us_gun_campaign_2017` and `us_mother_load_campaign_2017`